### PR TITLE
build: 1.0.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -40,7 +40,7 @@
 
     <version>1.0.1-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
-    <artifactId>client</artifactId>
+    <artifactId>questdb-client</artifactId>
     <packaging>jar</packaging>
 
     <url>https://questdb.io/</url>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,7 +38,7 @@
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
     </properties>
 
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <groupId>org.questdb</groupId>
     <artifactId>questdb-client</artifactId>
     <packaging>jar</packaging>
@@ -62,7 +62,7 @@
     <scm>
         <url>scm:git:https://github.com/questdb/java-questdb-client.git</url>
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
-        <tag>HEAD</tag>
+        <tag>1.0.1</tag>
     </scm>
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,7 +38,7 @@
         <test.include>%regex[.*[^o].class]</test.include><!-- exclude module-info.class-->
     </properties>
 
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
     <artifactId>questdb-client</artifactId>
     <packaging>jar</packaging>
@@ -62,7 +62,7 @@
     <scm>
         <url>scm:git:https://github.com/questdb/java-questdb-client.git</url>
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
-        <tag>1.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>org.questdb</groupId>
-            <artifactId>client</artifactId>
+            <artifactId>questdb-client</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.questdb</groupId>
     <artifactId>client-examples</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>Examples for QuestDB</name>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.questdb</groupId>
     <artifactId>client-examples</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <name>Examples for QuestDB</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
     <artifactId>client-parent</artifactId>
     <packaging>pom</packaging>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
         <developerConnection>scm:git:https://github.com/questdb/java-questdb-client.git</developerConnection>
         <url>https://github.com/questdb/java-questdb-client</url>
-        <tag>1.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <groupId>org.questdb</groupId>
     <artifactId>client-parent</artifactId>
     <packaging>pom</packaging>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
         <developerConnection>scm:git:https://github.com/questdb/java-questdb-client.git</developerConnection>
         <url>https://github.com/questdb/java-questdb-client</url>
-        <tag>HEAD</tag>
+        <tag>1.0.1</tag>
     </scm>
 
     <build>


### PR DESCRIPTION
## Summary
- Rename Maven artifact ID from `client` to `questdb-client` for better discoverability
- Update dependency reference in examples module

The published artifact will now be `org.questdb:questdb-client` instead of `org.questdb:client`.

## Test plan
- [x] Verify `mvn clean install` succeeds
- [x] Confirm artifact is correctly named in local Maven repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)