### PR TITLE
fix(ilp): surface WebSocket frame-size errors to sender callers

### DIFF
--- a/core/src/main/java/io/questdb/client/Sender.java
+++ b/core/src/main/java/io/questdb/client/Sender.java
@@ -102,6 +102,11 @@ import java.util.concurrent.TimeUnit;
  * <br>
  * Note: If the underlying error is permanent, retrying {@link #flush()} will fail again.
  * Use {@link #reset()} to discard the problematic data and continue with new data.
+ * <br>
+ * Note: WebSocket transport uses a terminal sender-level failure model after a
+ * connection has been established. After a WebSocket send, ACK, or connection
+ * failure, {@link #reset()} does not recover the sender; close it and create a
+ * new one.
  *
  */
 public interface Sender extends Closeable, ArraySender<Sender> {

--- a/core/src/main/java/io/questdb/client/cutlass/http/client/WebSocketSendBuffer.java
+++ b/core/src/main/java/io/questdb/client/cutlass/http/client/WebSocketSendBuffer.java
@@ -334,7 +334,7 @@ public class WebSocketSendBuffer implements QwpBufferWriter, QuietCloseable {
         int charLen = value.length();
         ensureCapacity(charLen);
 
-        // Single-pass ASCII path. Non-ASCII falls back to the shared UTF-8 utility.
+        // Single-pass for ASCII. Mixed strings keep the ASCII prefix and resume UTF-8 encoding.
         long addr = bufPtr + writePos;
         int i = 0;
         for (; i < charLen; i++) {
@@ -348,9 +348,9 @@ public class WebSocketSendBuffer implements QwpBufferWriter, QuietCloseable {
         if (i == charLen) {
             writePos += charLen;
         } else {
-            int utf8Len = NativeBufferWriter.utf8Length(value);
-            ensureCapacity(utf8Len);
-            writePos += Utf8s.strCpyUtf8(value, bufPtr + writePos, utf8Len);
+            int utf8Len = Utf8s.utf8Bytes(value, i, charLen);
+            ensureCapacity(i + utf8Len);
+            writePos += i + Utf8s.strCpyUtf8(value, i, bufPtr + writePos + i, utf8Len);
         }
     }
 

--- a/core/src/main/java/io/questdb/client/cutlass/http/client/WebSocketSendBuffer.java
+++ b/core/src/main/java/io/questdb/client/cutlass/http/client/WebSocketSendBuffer.java
@@ -35,6 +35,7 @@ import io.questdb.client.std.QuietCloseable;
 import io.questdb.client.std.SecureRnd;
 import io.questdb.client.std.Unsafe;
 import io.questdb.client.std.Vect;
+import io.questdb.client.std.str.Utf8s;
 
 /**
  * Zero-GC WebSocket send buffer that implements {@link ArrayBufferAppender} for direct
@@ -208,13 +209,13 @@ public class WebSocketSendBuffer implements QwpBufferWriter, QuietCloseable {
     }
 
     @Override
-    public long getWriteAddress() {
-        return bufPtr + writePos;
+    public int getWritableBytes() {
+        return bufCapacity - writePos;
     }
 
     @Override
-    public int getWritableBytes() {
-        return bufCapacity - writePos;
+    public long getWriteAddress() {
+        return bufPtr + writePos;
     }
 
     /**
@@ -329,32 +330,27 @@ public class WebSocketSendBuffer implements QwpBufferWriter, QuietCloseable {
         if (value == null || value.isEmpty()) {
             return;
         }
-        for (int i = 0, n = value.length(); i < n; i++) {
+
+        int charLen = value.length();
+        ensureCapacity(charLen);
+
+        // Single-pass ASCII path. Non-ASCII falls back to the shared UTF-8 utility.
+        long addr = bufPtr + writePos;
+        int i = 0;
+        for (; i < charLen; i++) {
             char c = value.charAt(i);
-            if (c < 0x80) {
-                putByte((byte) c);
-            } else if (c < 0x800) {
-                putByte((byte) (0xC0 | (c >> 6)));
-                putByte((byte) (0x80 | (c & 0x3F)));
-            } else if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
-                char c2 = value.charAt(++i);
-                if (Character.isLowSurrogate(c2)) {
-                    int codePoint = 0x10000 + ((c - 0xD800) << 10) + (c2 - 0xDC00);
-                    putByte((byte) (0xF0 | (codePoint >> 18)));
-                    putByte((byte) (0x80 | ((codePoint >> 12) & 0x3F)));
-                    putByte((byte) (0x80 | ((codePoint >> 6) & 0x3F)));
-                    putByte((byte) (0x80 | (codePoint & 0x3F)));
-                } else {
-                    putByte((byte) '?');
-                    i--;
-                }
-            } else if (Character.isSurrogate(c)) {
-                putByte((byte) '?');
-            } else {
-                putByte((byte) (0xE0 | (c >> 12)));
-                putByte((byte) (0x80 | ((c >> 6) & 0x3F)));
-                putByte((byte) (0x80 | (c & 0x3F)));
+            if (c >= 0x80) {
+                break;
             }
+            Unsafe.getUnsafe().putByte(addr++, (byte) c);
+        }
+
+        if (i == charLen) {
+            writePos += charLen;
+        } else {
+            int utf8Len = NativeBufferWriter.utf8Length(value);
+            ensureCapacity(utf8Len);
+            writePos += Utf8s.strCpyUtf8(value, bufPtr + writePos, utf8Len);
         }
     }
 
@@ -397,10 +393,10 @@ public class WebSocketSendBuffer implements QwpBufferWriter, QuietCloseable {
      */
     public FrameInfo writeCloseFrame(int code, String reason) {
         int payloadLen = 2; // status code
-        byte[] reasonBytes = null;
+        int reasonLen = 0;
         if (reason != null && !reason.isEmpty()) {
-            reasonBytes = reason.getBytes(java.nio.charset.StandardCharsets.UTF_8);
-            payloadLen += reasonBytes.length;
+            reasonLen = Utf8s.utf8Bytes(reason);
+            payloadLen += reasonLen;
         }
 
         if (payloadLen > 125) {
@@ -422,10 +418,8 @@ public class WebSocketSendBuffer implements QwpBufferWriter, QuietCloseable {
         writePos += 2;
 
         // Write reason if present
-        if (reasonBytes != null) {
-            for (byte reasonByte : reasonBytes) {
-                Unsafe.getUnsafe().putByte(bufPtr + writePos++, reasonByte);
-            }
+        if (reasonLen > 0) {
+            writePos += Utf8s.strCpyUtf8(reason, bufPtr + writePos, reasonLen);
         }
 
         // Mask the payload (including status code and reason)

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/NativeBufferWriter.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/NativeBufferWriter.java
@@ -27,6 +27,7 @@ package io.questdb.client.cutlass.qwp.client;
 import io.questdb.client.std.MemoryTag;
 import io.questdb.client.std.QuietCloseable;
 import io.questdb.client.std.Unsafe;
+import io.questdb.client.std.str.Utf8s;
 
 /**
  * A simple native memory buffer writer for encoding QWP v1 messages.
@@ -61,24 +62,7 @@ public class NativeBufferWriter implements QwpBufferWriter, QuietCloseable {
      * @return the number of bytes needed to encode the string as UTF-8
      */
     public static int utf8Length(String s) {
-        if (s == null) return 0;
-        int len = 0;
-        for (int i = 0, n = s.length(); i < n; i++) {
-            char c = s.charAt(i);
-            if (c < 0x80) {
-                len++;
-            } else if (c < 0x800) {
-                len += 2;
-            } else if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n && Character.isLowSurrogate(s.charAt(i + 1))) {
-                i++;
-                len += 4;
-            } else if (Character.isSurrogate(c)) {
-                len++;
-            } else {
-                len += 3;
-            }
-        }
-        return len;
+        return s == null ? 0 : Utf8s.utf8Bytes(s);
     }
 
     /**
@@ -274,7 +258,7 @@ public class NativeBufferWriter implements QwpBufferWriter, QuietCloseable {
             int utf8Len = utf8Length(value);
             putVarint(utf8Len);
             ensureCapacity(utf8Len);
-            encodeUtf8(value);
+            encodeUtf8(value, utf8Len);
         }
     }
 
@@ -308,7 +292,7 @@ public class NativeBufferWriter implements QwpBufferWriter, QuietCloseable {
             // Non-ASCII — fall back to two-pass (re-encodes from start)
             int utf8Len = utf8Length(value);
             ensureCapacity(utf8Len);
-            encodeUtf8(value);
+            encodeUtf8(value, utf8Len);
         }
     }
 
@@ -355,35 +339,7 @@ public class NativeBufferWriter implements QwpBufferWriter, QuietCloseable {
         Unsafe.getUnsafe().putByte(addr, (byte) value);
     }
 
-    private void encodeUtf8(String value) {
-        long addr = bufferPtr + position;
-        for (int i = 0, n = value.length(); i < n; i++) {
-            char c = value.charAt(i);
-            if (c < 0x80) {
-                Unsafe.getUnsafe().putByte(addr++, (byte) c);
-            } else if (c < 0x800) {
-                Unsafe.getUnsafe().putByte(addr++, (byte) (0xC0 | (c >> 6)));
-                Unsafe.getUnsafe().putByte(addr++, (byte) (0x80 | (c & 0x3F)));
-            } else if (c >= 0xD800 && c <= 0xDBFF && i + 1 < n) {
-                char c2 = value.charAt(++i);
-                if (Character.isLowSurrogate(c2)) {
-                    int codePoint = 0x10000 + ((c - 0xD800) << 10) + (c2 - 0xDC00);
-                    Unsafe.getUnsafe().putByte(addr++, (byte) (0xF0 | (codePoint >> 18)));
-                    Unsafe.getUnsafe().putByte(addr++, (byte) (0x80 | ((codePoint >> 12) & 0x3F)));
-                    Unsafe.getUnsafe().putByte(addr++, (byte) (0x80 | ((codePoint >> 6) & 0x3F)));
-                    Unsafe.getUnsafe().putByte(addr++, (byte) (0x80 | (codePoint & 0x3F)));
-                } else {
-                    Unsafe.getUnsafe().putByte(addr++, (byte) '?');
-                    i--;
-                }
-            } else if (Character.isSurrogate(c)) {
-                Unsafe.getUnsafe().putByte(addr++, (byte) '?');
-            } else {
-                Unsafe.getUnsafe().putByte(addr++, (byte) (0xE0 | (c >> 12)));
-                Unsafe.getUnsafe().putByte(addr++, (byte) (0x80 | ((c >> 6) & 0x3F)));
-                Unsafe.getUnsafe().putByte(addr++, (byte) (0x80 | (c & 0x3F)));
-            }
-        }
-        position = (int) (addr - bufferPtr);
+    private void encodeUtf8(String value, int utf8Len) {
+        position += Utf8s.strCpyUtf8(value, bufferPtr + position, utf8Len);
     }
 }

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/NativeBufferWriter.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/NativeBufferWriter.java
@@ -289,10 +289,9 @@ public class NativeBufferWriter implements QwpBufferWriter, QuietCloseable {
             // All ASCII — done in a single pass
             position += charLen;
         } else {
-            // Non-ASCII — fall back to two-pass (re-encodes from start)
-            int utf8Len = utf8Length(value);
-            ensureCapacity(utf8Len);
-            encodeUtf8(value, utf8Len);
+            int utf8Len = Utf8s.utf8Bytes(value, i, charLen);
+            ensureCapacity(i + utf8Len);
+            position += i + Utf8s.strCpyUtf8(value, i, bufferPtr + position + i, utf8Len);
         }
     }
 

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
@@ -51,6 +51,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * QWP v1 WebSocket client sender for streaming data to QuestDB.
@@ -112,6 +113,7 @@ public class QwpWebSocketSender implements Sender {
     private final String host;
     // Flow control configuration
     private final int inFlightWindowSize;
+    private final AtomicReference<LineSenderException> connectionError = new AtomicReference<>();
     private final int maxSchemasPerConnection;
     private final int port;
     private final CharSequenceObjHashMap<QwpTableBuffer> tableBuffers;
@@ -482,7 +484,7 @@ public class QwpWebSocketSender implements Sender {
 
             // Flush any remaining data
             try {
-                if (inFlightWindowSize > 1) {
+                if (connectionError.get() == null && inFlightWindowSize > 1) {
                     // Async mode (window > 1): flush accumulated rows in table buffers first
                     flushPendingRows();
 
@@ -496,7 +498,7 @@ public class QwpWebSocketSender implements Sender {
                     } else if (inFlightWindow != null) {
                         inFlightWindow.awaitEmpty();
                     }
-                } else {
+                } else if (connectionError.get() == null) {
                     // Sync mode (window=1): flush pending rows synchronously
                     if (pendingRowCount > 0 && client != null && client.isConnected()) {
                         flushSync();
@@ -744,10 +746,21 @@ public class QwpWebSocketSender implements Sender {
             }
 
             // Wait for all pending batches to be sent to the server
-            sendQueue.flush();
+            try {
+                sendQueue.flush();
+            } catch (LineSenderException e) {
+                checkConnectionError();
+                throw e;
+            }
 
             // Wait for all in-flight batches to be acknowledged by the server
-            sendQueue.awaitPendingAcks();
+            try {
+                sendQueue.awaitPendingAcks();
+            } catch (LineSenderException e) {
+                checkConnectionError();
+                throw e;
+            }
+            checkConnectionError();
 
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Flush complete [totalBatches={}, totalBytes={}, totalAcked={}]", sendQueue.getTotalBatchesSent(), sendQueue.getTotalBytesSent(), inFlightWindow.getTotalAcked());
@@ -1158,6 +1171,14 @@ public class QwpWebSocketSender implements Sender {
         if (closed) {
             throw new LineSenderException("Sender is closed");
         }
+        checkConnectionError();
+    }
+
+    private void checkConnectionError() {
+        LineSenderException error = connectionError.get();
+        if (error != null) {
+            throw error;
+        }
     }
 
     private void checkTableSelected() {
@@ -1200,9 +1221,7 @@ public class QwpWebSocketSender implements Sender {
     }
 
     private void ensureConnected() {
-        if (closed) {
-            throw new LineSenderException("Sender is closed");
-        }
+        checkNotClosed();
         if (!connected) {
             // Create WebSocket client using factory (zero-GC native implementation)
             if (tlsConfig != null) {
@@ -1232,7 +1251,8 @@ public class QwpWebSocketSender implements Sender {
                 try {
                     sendQueue = new WebSocketSendQueue(client, inFlightWindow,
                             WebSocketSendQueue.DEFAULT_ENQUEUE_TIMEOUT_MS,
-                            WebSocketSendQueue.DEFAULT_SHUTDOWN_TIMEOUT_MS);
+                            WebSocketSendQueue.DEFAULT_SHUTDOWN_TIMEOUT_MS,
+                            this::recordConnectionFailure);
                 } catch (Throwable t) {
                     inFlightWindow = null;
                     client.close();
@@ -1248,6 +1268,7 @@ public class QwpWebSocketSender implements Sender {
             // Server starts fresh on each connection, so any sender-local schema
             // IDs retained from a prior connection must be discarded as well.
             resetSchemaStateForNewConnection();
+            connectionError.set(null);
 
             connected = true;
             LOG.info("Connected to WebSocket [host={}, port={}, windowSize={}, qwpVersion={}]",
@@ -1264,10 +1285,14 @@ public class QwpWebSocketSender implements Sender {
         }
     }
 
-    private void failExpectedIfNeeded(long expectedSequence, LineSenderException error) {
-        if (inFlightWindow != null && inFlightWindow.getLastError() == null) {
-            inFlightWindow.fail(expectedSequence, error);
+    private void failConnectionIfNeeded(LineSenderException error) {
+        if (recordConnectionFailure(error) && inFlightWindow != null) {
+            inFlightWindow.failAll(error);
         }
+    }
+
+    private boolean recordConnectionFailure(LineSenderException error) {
+        return connectionError.compareAndSet(null, error);
     }
 
     /**
@@ -1451,6 +1476,7 @@ public class QwpWebSocketSender implements Sender {
 
         // Track batch in InFlightWindow before sending
         long batchSequence = nextBatchSequence++;
+        checkConnectionError();
         inFlightWindow.addInFlight(batchSequence);
 
         if (LOG.isDebugEnabled()) {
@@ -1462,11 +1488,11 @@ public class QwpWebSocketSender implements Sender {
         try {
             client.sendBinary(buffer.getBufferPtr(), messageSize);
         } catch (LineSenderException e) {
-            failExpectedIfNeeded(batchSequence, e);
+            failConnectionIfNeeded(e);
             throw e;
         } catch (Throwable t) {
             LineSenderException error = new LineSenderException("Failed to send batch " + batchSequence, t);
-            failExpectedIfNeeded(batchSequence, error);
+            failConnectionIfNeeded(error);
             throw error;
         }
 
@@ -1583,6 +1609,7 @@ public class QwpWebSocketSender implements Sender {
             if (toSend.isSealed()) {
                 toSend.rollbackSealForRetry();
             }
+            checkConnectionError();
             throw e;
         }
     }
@@ -1701,24 +1728,22 @@ public class QwpWebSocketSender implements Sender {
                         LineSenderException error = new LineSenderException(
                                 "Server error for batch " + sequence + ": " +
                                         ackResponse.getStatusName() + " - " + errorMessage);
-                        inFlightWindow.fail(sequence, error);
-                        if (sequence == expectedSequence) {
-                            throw error;
-                        }
+                        failConnectionIfNeeded(error);
+                        throw error;
                     }
                 }
             } catch (LineSenderException e) {
-                failExpectedIfNeeded(expectedSequence, e);
+                failConnectionIfNeeded(e);
                 throw e;
             } catch (Exception e) {
                 LineSenderException wrapped = new LineSenderException("Error waiting for ACK: " + e.getMessage(), e);
-                failExpectedIfNeeded(expectedSequence, wrapped);
+                failConnectionIfNeeded(wrapped);
                 throw wrapped;
             }
         }
 
         LineSenderException timeout = new LineSenderException("Timeout waiting for ACK for batch " + expectedSequence);
-        failExpectedIfNeeded(expectedSequence, timeout);
+        failConnectionIfNeeded(timeout);
         throw timeout;
     }
 
@@ -1744,7 +1769,7 @@ public class QwpWebSocketSender implements Sender {
 
         @Override
         public void onClose(int code, String reason) {
-            throw new LineSenderException("WebSocket closed while waiting for ACK: " + reason);
+            throw new LineSenderException("WebSocket closed while waiting for ACK [code=" + code + ", reason=" + reason + ']');
         }
     }
 }

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
@@ -1202,6 +1202,10 @@ public class QwpWebSocketSender implements Sender {
     private void checkConnectionError() {
         LineSenderException error = connectionError.get();
         if (error != null) {
+            // Refresh the stack so subsequent public API calls point at the
+            // call that observed the terminal sender state, not the I/O thread
+            // that originally recorded the failure.
+            error.fillInStackTrace();
             throw error;
         }
     }

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
@@ -85,6 +85,17 @@ import java.util.concurrent.atomic.AtomicReference;
  *     sender.flush();
  * }
  * </pre>
+ * <p>
+ * Failure handling: after this sender has established a WebSocket connection,
+ * any WebSocket send failure, receive failure, ACK timeout, server error ACK,
+ * invalid ACK, or server close is terminal for this sender instance. The first
+ * such failure is retained and subsequent public operations rethrow the same
+ * {@link LineSenderException}. {@link #reset()} only discards buffered row data;
+ * it does not recover a terminal WebSocket failure. To resume sending after a
+ * terminal WebSocket failure, close this sender and create a new instance.
+ * <p>
+ * Initial connection failures are not retained as terminal sender state; a later
+ * operation may try to connect again.
  */
 public class QwpWebSocketSender implements Sender {
 
@@ -730,6 +741,20 @@ public class QwpWebSocketSender implements Sender {
         return this;
     }
 
+    /**
+     * Flushes buffered rows and waits until the server acknowledges all submitted
+     * WebSocket batches.
+     * <p>
+     * If a WebSocket send, receive, ACK timeout, server error ACK, invalid ACK,
+     * or server close is observed after the connection has been established, the
+     * sender enters a terminal failed state. The first failure is retained and
+     * subsequent public operations rethrow the same {@link LineSenderException}.
+     * Create a new sender to resume sending.
+     *
+     * @throws LineSenderException if the sender is closed, a row is still in
+     *                             progress, connection setup fails, or a terminal
+     *                             WebSocket failure is observed
+     */
     @Override
     public void flush() {
         checkNotClosed();

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/WebSocketResponse.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/WebSocketResponse.java
@@ -25,6 +25,7 @@
 package io.questdb.client.cutlass.qwp.client;
 
 import io.questdb.client.std.Unsafe;
+import io.questdb.client.std.str.Utf8s;
 
 import java.nio.charset.StandardCharsets;
 
@@ -219,8 +220,7 @@ public class WebSocketResponse {
     public int serializedSize() {
         int size = MIN_RESPONSE_SIZE;
         if (errorMessage != null && !errorMessage.isEmpty()) {
-            byte[] msgBytes = errorMessage.getBytes(StandardCharsets.UTF_8);
-            int msgLen = Math.min(msgBytes.length, MAX_ERROR_MESSAGE_LENGTH);
+            int msgLen = Utf8s.utf8Bytes(errorMessage, MAX_ERROR_MESSAGE_LENGTH);
             size += 2 + msgLen; // 2 bytes for length prefix
         }
         return size;
@@ -255,18 +255,14 @@ public class WebSocketResponse {
 
         // Error message (if any)
         if (status != STATUS_OK && errorMessage != null && !errorMessage.isEmpty()) {
-            byte[] msgBytes = errorMessage.getBytes(StandardCharsets.UTF_8);
-            int msgLen = Math.min(msgBytes.length, MAX_ERROR_MESSAGE_LENGTH);
+            int msgLen = Utf8s.utf8Bytes(errorMessage, MAX_ERROR_MESSAGE_LENGTH);
 
             // Length prefix (2 bytes, little-endian)
             Unsafe.getUnsafe().putShort(ptr + offset, (short) msgLen);
             offset += 2;
 
             // Message bytes
-            for (int i = 0; i < msgLen; i++) {
-                Unsafe.getUnsafe().putByte(ptr + offset + i, msgBytes[i]);
-            }
-            offset += msgLen;
+            offset += Utf8s.strCpyUtf8(errorMessage, ptr + offset, msgLen);
         }
 
         return offset;

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/WebSocketResponse.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/WebSocketResponse.java
@@ -67,6 +67,7 @@ public class WebSocketResponse {
     public static final byte STATUS_SECURITY_ERROR = 0x08;
     public static final byte STATUS_WRITE_ERROR = 0x09;
     private String errorMessage;
+    private int errorMessageUtf8Length;
     private long sequence;
     private byte status;
 
@@ -74,6 +75,7 @@ public class WebSocketResponse {
         this.status = STATUS_OK;
         this.sequence = 0;
         this.errorMessage = null;
+        this.errorMessageUtf8Length = -1;
     }
 
     /**
@@ -84,6 +86,7 @@ public class WebSocketResponse {
         response.status = status;
         response.sequence = sequence;
         response.errorMessage = errorMessage;
+        response.errorMessageUtf8Length = -1;
         return response;
     }
 
@@ -125,6 +128,7 @@ public class WebSocketResponse {
         WebSocketResponse response = new WebSocketResponse();
         response.status = STATUS_OK;
         response.sequence = sequence;
+        response.errorMessageUtf8Length = -1;
         return response;
     }
 
@@ -204,11 +208,14 @@ public class WebSocketResponse {
                     msgBytes[i] = Unsafe.getUnsafe().getByte(ptr + offset + i);
                 }
                 errorMessage = new String(msgBytes, StandardCharsets.UTF_8);
+                errorMessageUtf8Length = -1;
             } else {
                 errorMessage = null;
+                errorMessageUtf8Length = 0;
             }
         } else {
             errorMessage = null;
+            errorMessageUtf8Length = -1;
         }
 
         return true;
@@ -218,12 +225,10 @@ public class WebSocketResponse {
      * Calculates the serialized size of this response.
      */
     public int serializedSize() {
-        int size = MIN_RESPONSE_SIZE;
-        if (errorMessage != null && !errorMessage.isEmpty()) {
-            int msgLen = Utf8s.utf8Bytes(errorMessage, MAX_ERROR_MESSAGE_LENGTH);
-            size += 2 + msgLen; // 2 bytes for length prefix
+        if (status == STATUS_OK) {
+            return MIN_RESPONSE_SIZE;
         }
-        return size;
+        return MIN_ERROR_RESPONSE_SIZE + getErrorMessageUtf8Length();
     }
 
     @Override
@@ -253,18 +258,30 @@ public class WebSocketResponse {
         Unsafe.getUnsafe().putLong(ptr + offset, sequence);
         offset += 8;
 
-        // Error message (if any)
-        if (status != STATUS_OK && errorMessage != null && !errorMessage.isEmpty()) {
-            int msgLen = Utf8s.utf8Bytes(errorMessage, MAX_ERROR_MESSAGE_LENGTH);
-
+        // Error message length and bytes (if any)
+        if (status != STATUS_OK) {
+            int msgLen = getErrorMessageUtf8Length();
             // Length prefix (2 bytes, little-endian)
             Unsafe.getUnsafe().putShort(ptr + offset, (short) msgLen);
             offset += 2;
 
             // Message bytes
-            offset += Utf8s.strCpyUtf8(errorMessage, ptr + offset, msgLen);
+            if (msgLen > 0) {
+                offset += Utf8s.strCpyUtf8(errorMessage, ptr + offset, msgLen);
+            }
         }
 
         return offset;
+    }
+
+    private int getErrorMessageUtf8Length() {
+        if (status == STATUS_OK || errorMessage == null || errorMessage.isEmpty()) {
+            errorMessageUtf8Length = 0;
+            return 0;
+        }
+        if (errorMessageUtf8Length < 0) {
+            errorMessageUtf8Length = Utf8s.utf8Bytes(errorMessage, MAX_ERROR_MESSAGE_LENGTH);
+        }
+        return errorMessageUtf8Length;
     }
 }

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/WebSocketSendQueue.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/WebSocketSendQueue.java
@@ -73,6 +73,8 @@ public class WebSocketSendQueue implements QuietCloseable {
     private final WebSocketClient client;
     // Configuration
     private final long enqueueTimeoutMs;
+    @Nullable
+    private final ConnectionFailureListener connectionFailureListener;
     // Optional InFlightWindow for tracking sent batches awaiting ACK
     @Nullable
     private final InFlightWindow inFlightWindow;
@@ -121,6 +123,21 @@ public class WebSocketSendQueue implements QuietCloseable {
      */
     public WebSocketSendQueue(WebSocketClient client, @Nullable InFlightWindow inFlightWindow,
                               long enqueueTimeoutMs, long shutdownTimeoutMs) {
+        this(client, inFlightWindow, enqueueTimeoutMs, shutdownTimeoutMs, null);
+    }
+
+    /**
+     * Creates a new send queue with custom configuration.
+     *
+     * @param client                    the WebSocket client for I/O
+     * @param inFlightWindow            the window to track sent batches awaiting ACK (may be null)
+     * @param enqueueTimeoutMs          timeout for enqueue operations (ms)
+     * @param shutdownTimeoutMs         timeout for graceful shutdown (ms)
+     * @param connectionFailureListener notified once when the queue detects a terminal connection failure
+     */
+    public WebSocketSendQueue(WebSocketClient client, @Nullable InFlightWindow inFlightWindow,
+                              long enqueueTimeoutMs, long shutdownTimeoutMs,
+                              @Nullable ConnectionFailureListener connectionFailureListener) {
         if (client == null) {
             throw new IllegalArgumentException("client cannot be null");
         }
@@ -129,6 +146,7 @@ public class WebSocketSendQueue implements QuietCloseable {
         this.inFlightWindow = inFlightWindow;
         this.enqueueTimeoutMs = enqueueTimeoutMs;
         this.shutdownTimeoutMs = shutdownTimeoutMs;
+        this.connectionFailureListener = connectionFailureListener;
         this.running = true;
         this.shuttingDown = false;
         this.shutdownLatch = new CountDownLatch(1);
@@ -226,20 +244,20 @@ public class WebSocketSendQueue implements QuietCloseable {
             throw new LineSenderException("Buffer must be sealed before enqueue, state=" +
                     MicrobatchBuffer.stateName(buffer.getState()));
         }
+        checkError();
         if (!running || shuttingDown) {
+            checkError();
             throw new LineSenderException("Send queue is not running");
         }
-
-        // Check for errors from I/O thread
-        checkError();
 
         final long deadline = System.currentTimeMillis() + enqueueTimeoutMs;
         synchronized (processingLock) {
             while (true) {
+                checkError();
                 if (!running || shuttingDown) {
+                    checkError();
                     throw new LineSenderException("Send queue is not running");
                 }
-                checkError();
 
                 if (offerPending(buffer)) {
                     processingLock.notifyAll();
@@ -368,11 +386,19 @@ public class WebSocketSendQueue implements QuietCloseable {
         }
     }
 
-    private void failTransport(LineSenderException error) {
+    private void failConnection(LineSenderException error) {
         Throwable rootError = lastError;
+        boolean firstFailure = rootError == null;
         if (rootError == null) {
             lastError = error;
             rootError = error;
+        }
+        if (firstFailure && connectionFailureListener != null) {
+            try {
+                connectionFailureListener.onConnectionFailure(error);
+            } catch (Throwable t) {
+                LOG.error("Error notifying connection failure listener", t);
+            }
         }
         running = false;
         shuttingDown = true;
@@ -532,7 +558,7 @@ public class WebSocketSendQueue implements QuietCloseable {
             sendBatch(batch);
         } catch (Throwable t) {
             LOG.error("Error sending batch [id={}]{}", batch.getBatchId(), "", t);
-            failTransport(new LineSenderException("Error sending batch " + batch.getBatchId() + ": " + t.getMessage(), t));
+            failConnection(new LineSenderException("Error sending batch " + batch.getBatchId() + ": " + t.getMessage(), t));
             // Mark as recycled even on error to allow cleanup
             if (batch.isSealed()) {
                 batch.markSending();
@@ -608,7 +634,7 @@ public class WebSocketSendQueue implements QuietCloseable {
         } catch (Exception e) {
             if (running) {
                 LOG.error("Error receiving response: {}", e.getMessage());
-                failTransport(new LineSenderException("Error receiving response: " + e.getMessage(), e));
+                failConnection(new LineSenderException("Error receiving response: " + e.getMessage(), e));
             }
         }
         return received;
@@ -626,6 +652,11 @@ public class WebSocketSendQueue implements QuietCloseable {
         IDLE, ACTIVE, DRAINING
     }
 
+    @FunctionalInterface
+    public interface ConnectionFailureListener {
+        void onConnectionFailure(LineSenderException error);
+    }
+
     /**
      * Handler for received WebSocket frames (ACKs from server).
      */
@@ -638,7 +669,7 @@ public class WebSocketSendQueue implements QuietCloseable {
                         "Invalid ACK response payload [length=" + payloadLen + ']'
                 );
                 LOG.error("Invalid ACK response payload [length={}]", payloadLen);
-                failTransport(error);
+                failConnection(error);
                 return;
             }
 
@@ -646,7 +677,7 @@ public class WebSocketSendQueue implements QuietCloseable {
             if (!response.readFrom(payloadPtr, payloadLen)) {
                 LineSenderException error = new LineSenderException("Failed to parse ACK response");
                 LOG.error("Failed to parse response");
-                failTransport(error);
+                failConnection(error);
                 return;
             }
 
@@ -670,20 +701,18 @@ public class WebSocketSendQueue implements QuietCloseable {
                 String errorMessage = response.getErrorMessage();
                 LOG.error("Error response [seq={}, status={}, error={}]", sequence, response.getStatusName(), errorMessage);
 
-                if (inFlightWindow != null) {
-                    LineSenderException error = new LineSenderException(
-                            "Server error for batch " + sequence + ": " +
-                                    response.getStatusName() + " - " + errorMessage);
-                    inFlightWindow.fail(sequence, error);
-                }
+                LineSenderException error = new LineSenderException(
+                        "Server error for batch " + sequence + ": " +
+                                response.getStatusName() + " - " + errorMessage);
                 totalErrors.incrementAndGet();
+                failConnection(error);
             }
         }
 
         @Override
         public void onClose(int code, String reason) {
             LOG.info("WebSocket closed by server [code={}, reason={}]", code, reason);
-            failTransport(new LineSenderException("WebSocket closed by server [code=" + code + ", reason=" + reason + ']'));
+            failConnection(new LineSenderException("WebSocket closed by server [code=" + code + ", reason=" + reason + ']'));
         }
     }
 }

--- a/core/src/main/java/io/questdb/client/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/client/std/str/Utf8s.java
@@ -173,6 +173,62 @@ public final class Utf8s {
         }
     }
 
+    /**
+     * Encodes a UTF-16 sequence as UTF-8 directly into memory. Writes at most
+     * {@code maxBytes} bytes without splitting multi-byte sequences. Invalid
+     * surrogates are replaced with '?'.
+     *
+     * @return the number of UTF-8 bytes written
+     */
+    public static int strCpyUtf8(@NotNull CharSequence src, long destAddr, int maxBytes) {
+        int pos = 0;
+        for (int i = 0, n = src.length(); i < n; i++) {
+            char c = src.charAt(i);
+            if (c < 0x80) {
+                if (pos + 1 > maxBytes) {
+                    break;
+                }
+                Unsafe.getUnsafe().putByte(destAddr + pos, (byte) c);
+                pos++;
+            } else if (c < 0x800) {
+                if (pos + 2 > maxBytes) {
+                    break;
+                }
+                Unsafe.getUnsafe().putByte(destAddr + pos, (byte) (192 | c >> 6));
+                Unsafe.getUnsafe().putByte(destAddr + pos + 1, (byte) (128 | c & 63));
+                pos += 2;
+            } else if (Character.isSurrogate(c)) {
+                if (Character.isHighSurrogate(c) && i + 1 < n && Character.isLowSurrogate(src.charAt(i + 1))) {
+                    if (pos + 4 > maxBytes) {
+                        break;
+                    }
+                    int cp = Character.toCodePoint(c, src.charAt(i + 1));
+                    Unsafe.getUnsafe().putByte(destAddr + pos, (byte) (240 | cp >> 18));
+                    Unsafe.getUnsafe().putByte(destAddr + pos + 1, (byte) (128 | cp >> 12 & 63));
+                    Unsafe.getUnsafe().putByte(destAddr + pos + 2, (byte) (128 | cp >> 6 & 63));
+                    Unsafe.getUnsafe().putByte(destAddr + pos + 3, (byte) (128 | cp & 63));
+                    pos += 4;
+                    i++;
+                } else {
+                    if (pos + 1 > maxBytes) {
+                        break;
+                    }
+                    Unsafe.getUnsafe().putByte(destAddr + pos, (byte) '?');
+                    pos++;
+                }
+            } else {
+                if (pos + 3 > maxBytes) {
+                    break;
+                }
+                Unsafe.getUnsafe().putByte(destAddr + pos, (byte) (224 | c >> 12));
+                Unsafe.getUnsafe().putByte(destAddr + pos + 1, (byte) (128 | c >> 6 & 63));
+                Unsafe.getUnsafe().putByte(destAddr + pos + 2, (byte) (128 | c & 63));
+                pos += 3;
+            }
+        }
+        return pos;
+    }
+
     public static String stringFromUtf8Bytes(long lo, long hi) {
         if (hi == lo) {
             return "";
@@ -204,6 +260,67 @@ public final class Utf8s {
             throw CairoException.nonCritical().put("cannot convert invalid UTF-8 sequence to UTF-16 [seq=").put(seq).put(']');
         }
         return b.toString();
+    }
+
+    public static int utf8Bytes(@NotNull CharSequence sequence) {
+        int count = 0;
+        int len = sequence.length();
+
+        for (int i = 0; i < len; i++) {
+            char ch = sequence.charAt(i);
+            if (ch < 0x80) {
+                count++;
+            } else if (ch < 0x800) {
+                count += 2;
+            } else if (Character.isSurrogate(ch)) {
+                if (Character.isHighSurrogate(ch)) {
+                    if (i + 1 < len && Character.isLowSurrogate(sequence.charAt(i + 1))) {
+                        count += 4;
+                        i++;
+                    } else {
+                        count++;
+                    }
+                } else {
+                    count++;
+                }
+            } else {
+                count += 3;
+            }
+        }
+        return count;
+    }
+
+    public static int utf8Bytes(@NotNull CharSequence sequence, int maxBytes) {
+        int count = 0;
+        int len = sequence.length();
+
+        for (int i = 0; i < len; i++) {
+            char ch = sequence.charAt(i);
+            int charBytes;
+            if (ch < 0x80) {
+                charBytes = 1;
+            } else if (ch < 0x800) {
+                charBytes = 2;
+            } else if (Character.isSurrogate(ch)) {
+                if (Character.isHighSurrogate(ch) && i + 1 < len && Character.isLowSurrogate(sequence.charAt(i + 1))) {
+                    charBytes = 4;
+                    if (count + charBytes > maxBytes) {
+                        break;
+                    }
+                    count += charBytes;
+                    i++;
+                    continue;
+                }
+                charBytes = 1;
+            } else {
+                charBytes = 3;
+            }
+            if (count + charBytes > maxBytes) {
+                break;
+            }
+            count += charBytes;
+        }
+        return count;
     }
 
     public static int utf8DecodeMultiByte(long lo, long hi, byte b, Utf16Sink sink) {

--- a/core/src/main/java/io/questdb/client/std/str/Utf8s.java
+++ b/core/src/main/java/io/questdb/client/std/str/Utf8s.java
@@ -181,8 +181,12 @@ public final class Utf8s {
      * @return the number of UTF-8 bytes written
      */
     public static int strCpyUtf8(@NotNull CharSequence src, long destAddr, int maxBytes) {
+        return strCpyUtf8(src, 0, destAddr, maxBytes);
+    }
+
+    public static int strCpyUtf8(@NotNull CharSequence src, int srcLo, long destAddr, int maxBytes) {
         int pos = 0;
-        for (int i = 0, n = src.length(); i < n; i++) {
+        for (int i = srcLo, n = src.length(); i < n; i++) {
             char c = src.charAt(i);
             if (c < 0x80) {
                 if (pos + 1 > maxBytes) {
@@ -263,10 +267,12 @@ public final class Utf8s {
     }
 
     public static int utf8Bytes(@NotNull CharSequence sequence) {
-        int count = 0;
-        int len = sequence.length();
+        return utf8Bytes(sequence, 0, sequence.length());
+    }
 
-        for (int i = 0; i < len; i++) {
+    public static int utf8Bytes(@NotNull CharSequence sequence, int lo, int hi) {
+        int count = 0;
+        for (int i = lo; i < hi; i++) {
             char ch = sequence.charAt(i);
             if (ch < 0x80) {
                 count++;
@@ -274,7 +280,7 @@ public final class Utf8s {
                 count += 2;
             } else if (Character.isSurrogate(ch)) {
                 if (Character.isHighSurrogate(ch)) {
-                    if (i + 1 < len && Character.isLowSurrogate(sequence.charAt(i + 1))) {
+                    if (i + 1 < hi && Character.isLowSurrogate(sequence.charAt(i + 1))) {
                         count += 4;
                         i++;
                     } else {

--- a/core/src/test/java/io/questdb/client/test/cutlass/http/client/WebSocketSendBufferTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/http/client/WebSocketSendBufferTest.java
@@ -26,9 +26,10 @@ package io.questdb.client.test.cutlass.http.client;
 
 import io.questdb.client.cutlass.http.client.WebSocketSendBuffer;
 import io.questdb.client.std.Unsafe;
-import static io.questdb.client.test.tools.TestUtils.assertMemoryLeak;
+import io.questdb.client.std.str.Utf8s;
 import org.junit.Test;
 
+import static io.questdb.client.test.tools.TestUtils.assertMemoryLeak;
 import static org.junit.Assert.assertEquals;
 
 public class WebSocketSendBufferTest {
@@ -43,6 +44,21 @@ public class WebSocketSendBufferTest {
                 assertEquals(2, buf.getWritePos());
                 assertEquals((byte) '?', Unsafe.getUnsafe().getByte(buf.getBufferPtr()));
                 assertEquals((byte) 'X', Unsafe.getUnsafe().getByte(buf.getBufferPtr() + 1));
+            }
+        });
+    }
+
+    @Test
+    public void testPutUtf8MixedAsciiAndNonAsciiAfterGrow() throws Exception {
+        assertMemoryLeak(() -> {
+            try (WebSocketSendBuffer buf = new WebSocketSendBuffer(8)) {
+                String value = "abcdefghijklmnop世界世界世界世界世界世界世界世界世界世界";
+
+                buf.putUtf8(value);
+
+                int utf8Len = Utf8s.utf8Bytes(value);
+                assertEquals(utf8Len, buf.getWritePos());
+                assertEquals(value, Utf8s.stringFromUtf8Bytes(buf.getBufferPtr(), buf.getBufferPtr() + utf8Len));
             }
         });
     }

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/AsyncModeIntegrationTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/AsyncModeIntegrationTest.java
@@ -461,8 +461,8 @@ public class AsyncModeIntegrationTest {
 
     /**
      * The server ACKs the first batch but returns a WRITE_ERROR for the
-     * second. {@link WebSocketSendQueue#flush()} completes (both batches
-     * were sent) but {@link InFlightWindow#awaitEmpty()} surfaces the error.
+     * second. The error is treated as a terminal connection failure and is
+     * surfaced by the next queue operation.
      */
     @Test
     public void testServerErrorPropagatesOnFlush() throws Exception {
@@ -471,6 +471,7 @@ public class AsyncModeIntegrationTest {
             FakeWebSocketClient client = new FakeWebSocketClient();
             AtomicLong highestSent = new AtomicLong(-1);
             AtomicLong highestDelivered = new AtomicLong(-1);
+            CountDownLatch errorDelivered = new CountDownLatch(1);
 
             client.setSendBehavior((ptr, len) -> highestSent.incrementAndGet());
             client.setTryReceiveBehavior(handler -> {
@@ -481,6 +482,7 @@ public class AsyncModeIntegrationTest {
                     highestDelivered.set(next);
                     if (next == 1) {
                         emitDiskFullError(handler, next);
+                        errorDelivered.countDown();
                     } else {
                         emitAck(handler, next);
                     }
@@ -506,12 +508,10 @@ public class AsyncModeIntegrationTest {
                 buf1.seal();
                 queue.enqueue(buf1);
 
-                // flush() waits for the queue to drain (both batches sent).
-                queue.flush();
+                assertTrue("Expected server error ACK", errorDelivered.await(2, TimeUnit.SECONDS));
 
-                // awaitEmpty() surfaces the server error for batch 1.
                 try {
-                    window.awaitEmpty();
+                    queue.flush();
                     fail("Expected server error to propagate");
                 } catch (LineSenderException e) {
                     assertTrue("Error should mention server failure",

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/NativeBufferWriterTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/NativeBufferWriterTest.java
@@ -26,6 +26,7 @@ package io.questdb.client.test.cutlass.qwp.client;
 
 import io.questdb.client.cutlass.qwp.client.NativeBufferWriter;
 import io.questdb.client.std.Unsafe;
+import io.questdb.client.std.str.Utf8s;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -518,6 +519,21 @@ public class NativeBufferWriterTest {
                 Assert.assertEquals((byte) 'd', Unsafe.getUnsafe().getByte(writer.getBufferPtr() + 6));
                 Assert.assertEquals((byte) 'e', Unsafe.getUnsafe().getByte(writer.getBufferPtr() + 7));
                 Assert.assertEquals((byte) 'f', Unsafe.getUnsafe().getByte(writer.getBufferPtr() + 8));
+            }
+        });
+    }
+
+    @Test
+    public void testWriteUtf8MixedAsciiAndNonAsciiAfterGrow() throws Exception {
+        assertMemoryLeak(() -> {
+            try (NativeBufferWriter writer = new NativeBufferWriter(8)) {
+                String value = "abcdefghijklmnop世界世界世界世界世界世界世界世界世界世界";
+
+                writer.putUtf8(value);
+
+                int utf8Len = Utf8s.utf8Bytes(value);
+                Assert.assertEquals(utf8Len, writer.getPosition());
+                Assert.assertEquals(value, Utf8s.stringFromUtf8Bytes(writer.getBufferPtr(), writer.getBufferPtr() + utf8Len));
             }
         });
     }

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderStateTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderStateTest.java
@@ -24,6 +24,7 @@
 
 package io.questdb.client.test.cutlass.qwp.client;
 
+import io.questdb.client.cutlass.line.LineSenderException;
 import io.questdb.client.cutlass.qwp.client.InFlightWindow;
 import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
 import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
@@ -48,6 +49,40 @@ import static io.questdb.client.test.tools.TestUtils.assertMemoryLeak;
  * </ul>
  */
 public class QwpWebSocketSenderStateTest extends AbstractTest {
+
+    @Test
+    public void testConnectionFailureIsSenderLevelTerminalState() throws Exception {
+        assertMemoryLeak(() -> {
+            QwpWebSocketSender sender = QwpWebSocketSender.createForTesting(
+                    "localhost", 0, 10_000, 0, 0L, 8
+            );
+            try {
+                LineSenderException failure = new LineSenderException(
+                        "Server error for batch 7: WRITE_ERROR - disk full"
+                );
+                Assert.assertTrue(invokeRecordConnectionFailure(sender, failure));
+
+                try {
+                    sender.table("t");
+                    Assert.fail("Expected sender-level connection failure");
+                } catch (LineSenderException e) {
+                    Assert.assertSame(failure, e);
+                }
+
+                LineSenderException secondFailure = new LineSenderException("second failure");
+                Assert.assertFalse(invokeRecordConnectionFailure(sender, secondFailure));
+
+                try {
+                    sender.flush();
+                    Assert.fail("Expected original sender-level connection failure");
+                } catch (LineSenderException e) {
+                    Assert.assertSame(failure, e);
+                }
+            } finally {
+                sender.close();
+            }
+        });
+    }
 
     @Test
     public void testAutoFlushAccumulatesRowsAcrossAllTables() throws Exception {
@@ -317,6 +352,12 @@ public class QwpWebSocketSenderStateTest extends AbstractTest {
         Method method = target.getClass().getDeclaredMethod("resetSchemaStateForNewConnection");
         method.setAccessible(true);
         method.invoke(target);
+    }
+
+    private static boolean invokeRecordConnectionFailure(Object target, LineSenderException error) throws Exception {
+        Method method = target.getClass().getDeclaredMethod("recordConnectionFailure", LineSenderException.class);
+        method.setAccessible(true);
+        return (boolean) method.invoke(target, error);
     }
 
     private static void setField(Object target, String fieldName, Object value) throws Exception {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderStateTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderStateTest.java
@@ -67,6 +67,7 @@ public class QwpWebSocketSenderStateTest extends AbstractTest {
                     Assert.fail("Expected sender-level connection failure");
                 } catch (LineSenderException e) {
                     Assert.assertSame(failure, e);
+                    assertStackContains(e, "table");
                 }
 
                 LineSenderException secondFailure = new LineSenderException("second failure");
@@ -77,6 +78,7 @@ public class QwpWebSocketSenderStateTest extends AbstractTest {
                     Assert.fail("Expected original sender-level connection failure");
                 } catch (LineSenderException e) {
                     Assert.assertSame(failure, e);
+                    assertStackContains(e, "flush");
                 }
             } finally {
                 sender.close();
@@ -352,6 +354,16 @@ public class QwpWebSocketSenderStateTest extends AbstractTest {
         Method method = target.getClass().getDeclaredMethod("resetSchemaStateForNewConnection");
         method.setAccessible(true);
         method.invoke(target);
+    }
+
+    private static void assertStackContains(Throwable throwable, String methodName) {
+        for (StackTraceElement element : throwable.getStackTrace()) {
+            if (QwpWebSocketSender.class.getName().equals(element.getClassName())
+                    && methodName.equals(element.getMethodName())) {
+                return;
+            }
+        }
+        Assert.fail("Expected stack trace to contain QwpWebSocketSender." + methodName);
     }
 
     private static boolean invokeRecordConnectionFailure(Object target, LineSenderException error) throws Exception {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/WebSocketSendQueueTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/WebSocketSendQueueTest.java
@@ -271,6 +271,55 @@ public class WebSocketSendQueueTest {
     }
 
     @Test
+    public void testEnqueueAfterServerErrorAckSurfacesServerError() throws Exception {
+        assertMemoryLeak(() -> {
+            InFlightWindow window = new InFlightWindow(8, 5_000);
+            FakeWebSocketClient client = new FakeWebSocketClient();
+            WebSocketSendQueue queue = null;
+            MicrobatchBuffer batch0 = sealedBuffer((byte) 42);
+            MicrobatchBuffer batch1 = sealedBuffer((byte) 43);
+            CountDownLatch errorDelivered = new CountDownLatch(1);
+            AtomicBoolean fired = new AtomicBoolean(false);
+            AtomicLong highestSent = new AtomicLong(-1);
+            AtomicReference<LineSenderException> connectionFailure = new AtomicReference<>();
+
+            try {
+                client.setSendBehavior((dataPtr, length) -> highestSent.incrementAndGet());
+                client.setTryReceiveBehavior(handler -> {
+                    long sent = highestSent.get();
+                    if (sent >= 0 && fired.compareAndSet(false, true)) {
+                        emitError(handler, sent, WebSocketResponse.STATUS_WRITE_ERROR, "disk full");
+                        errorDelivered.countDown();
+                        return true;
+                    }
+                    return false;
+                });
+
+                queue = new WebSocketSendQueue(client, window, 1_000, 500, connectionFailure::set);
+                queue.enqueue(batch0);
+                assertTrue("Expected server error ACK callback", errorDelivered.await(2, TimeUnit.SECONDS));
+                assertNotNull("Expected connection failure callback", connectionFailure.get());
+                assertTrue(connectionFailure.get().getMessage(), connectionFailure.get().getMessage().contains("WRITE_ERROR"));
+                assertTrue(connectionFailure.get().getMessage(), connectionFailure.get().getMessage().contains("disk full"));
+
+                try {
+                    queue.enqueue(batch1);
+                    fail("Expected enqueue failure after server error ACK");
+                } catch (LineSenderException e) {
+                    assertTrue(e.getMessage(), e.getMessage().contains("WRITE_ERROR"));
+                    assertTrue(e.getMessage(), e.getMessage().contains("disk full"));
+                    assertSame(connectionFailure.get(), e.getCause());
+                }
+            } finally {
+                closeQuietly(queue);
+                batch0.close();
+                batch1.close();
+                client.close();
+            }
+        });
+    }
+
+    @Test
     public void testAwaitPendingAcksKeepsDrainNonBlocking() throws Exception {
         assertMemoryLeak(() -> {
             InFlightWindow window = new InFlightWindow(8, 5_000);
@@ -380,6 +429,18 @@ public class WebSocketSendQueueTest {
 
     private static void emitAck(WebSocketFrameHandler handler, long sequence) {
         WebSocketResponse response = WebSocketResponse.success(sequence);
+        int size = response.serializedSize();
+        long ptr = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
+        try {
+            response.writeTo(ptr);
+            handler.onBinaryMessage(ptr, size);
+        } finally {
+            Unsafe.free(ptr, size, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    private static void emitError(WebSocketFrameHandler handler, long sequence, byte status, String errorMessage) {
+        WebSocketResponse response = WebSocketResponse.error(sequence, status, errorMessage);
         int size = response.serializedSize();
         long ptr = Unsafe.malloc(size, MemoryTag.NATIVE_DEFAULT);
         try {

--- a/core/src/test/java/io/questdb/client/test/std/str/Utf8sTest.java
+++ b/core/src/test/java/io/questdb/client/test/std/str/Utf8sTest.java
@@ -248,6 +248,99 @@ public class Utf8sTest {
     }
 
     @Test
+    public void testStrCpyUtf8() {
+        final int bufSize = 64;
+        long mem = Unsafe.malloc(bufSize, MemoryTag.NATIVE_DEFAULT);
+        try {
+            fill(mem, bufSize, (byte) 0x7F);
+
+            Assert.assertEquals(0, Utf8s.strCpyUtf8("", mem, bufSize));
+            assertUntouched(mem, bufSize, (byte) 0x7F);
+
+            Assert.assertEquals(0, Utf8s.strCpyUtf8("hello", mem, 0));
+            assertUntouched(mem, bufSize, (byte) 0x7F);
+
+            assertStrCpyUtf8(mem, bufSize, "hello", bufSize, 5, "hello");
+            assertStrCpyUtf8(mem, bufSize, "éü", bufSize, 4, "éü");
+            assertStrCpyUtf8(mem, bufSize, "世界", bufSize, 6, "世界");
+            assertStrCpyUtf8(mem, bufSize, "\uD83D\uDE00", bufSize, 4, "\uD83D\uDE00");
+            assertStrCpyUtf8(mem, bufSize, "Aé世\uD83D\uDE00", bufSize, 10, "Aé世\uD83D\uDE00");
+        } finally {
+            Unsafe.free(mem, bufSize, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testStrCpyUtf8DoesNotSplitCharactersAtLimit() {
+        final int bufSize = 16;
+        long mem = Unsafe.malloc(bufSize, MemoryTag.NATIVE_DEFAULT);
+        try {
+            assertStrCpyUtf8(mem, bufSize, "abcdef", 3, 3, "abc");
+            assertStrCpyUtf8(mem, bufSize, "aéb", 2, 1, "a");
+            assertStrCpyUtf8(mem, bufSize, "a世b", 3, 1, "a");
+            assertStrCpyUtf8(mem, bufSize, "a\uD83D\uDE00b", 4, 1, "a");
+
+            assertStrCpyUtf8(mem, bufSize, "aé", 3, 3, "aé");
+            assertStrCpyUtf8(mem, bufSize, "a世", 4, 4, "a世");
+            assertStrCpyUtf8(mem, bufSize, "a\uD83D\uDE00", 5, 5, "a\uD83D\uDE00");
+        } finally {
+            Unsafe.free(mem, bufSize, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testStrCpyUtf8ReplacesInvalidSurrogates() {
+        final int bufSize = 16;
+        long mem = Unsafe.malloc(bufSize, MemoryTag.NATIVE_DEFAULT);
+        try {
+            assertStrCpyUtf8(mem, bufSize, "\uD83Da", bufSize, 2, "?a");
+            assertStrCpyUtf8(mem, bufSize, "\uDE00b", bufSize, 2, "?b");
+            assertStrCpyUtf8(mem, bufSize, "\uD83D", bufSize, 1, "?");
+            assertStrCpyUtf8(mem, bufSize, "\uDE00", bufSize, 1, "?");
+            assertStrCpyUtf8(mem, bufSize, "\uD83Da", 1, 1, "?");
+            assertStrCpyUtf8(mem, bufSize, "a\uD83D", 1, 1, "a");
+            assertStrCpyUtf8(mem, bufSize, "a\uDE00", 1, 1, "a");
+        } finally {
+            Unsafe.free(mem, bufSize, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
+    public void testUtf8Bytes() {
+        Assert.assertEquals(0, Utf8s.utf8Bytes(""));
+        Assert.assertEquals(5, Utf8s.utf8Bytes("hello"));
+        Assert.assertEquals(4, Utf8s.utf8Bytes("éü"));
+        Assert.assertEquals(6, Utf8s.utf8Bytes("世界"));
+        Assert.assertEquals(4, Utf8s.utf8Bytes("\uD83D\uDE00"));
+        Assert.assertEquals(10, Utf8s.utf8Bytes("Aé世\uD83D\uDE00"));
+        Assert.assertEquals(2, Utf8s.utf8Bytes("\uD83Da"));
+        Assert.assertEquals(2, Utf8s.utf8Bytes("\uDE00b"));
+        Assert.assertEquals(1, Utf8s.utf8Bytes("\uD83D"));
+        Assert.assertEquals(1, Utf8s.utf8Bytes("\uDE00"));
+    }
+
+    @Test
+    public void testUtf8BytesWithLimit() {
+        Assert.assertEquals(0, Utf8s.utf8Bytes("hello", 0));
+        Assert.assertEquals(5, Utf8s.utf8Bytes("hello", 10));
+        Assert.assertEquals(3, Utf8s.utf8Bytes("hello", 3));
+
+        Assert.assertEquals(1, Utf8s.utf8Bytes("aéb", 2));
+        Assert.assertEquals(3, Utf8s.utf8Bytes("aé", 3));
+
+        Assert.assertEquals(1, Utf8s.utf8Bytes("a世b", 3));
+        Assert.assertEquals(4, Utf8s.utf8Bytes("a世", 4));
+
+        Assert.assertEquals(1, Utf8s.utf8Bytes("a\uD83D\uDE00b", 4));
+        Assert.assertEquals(5, Utf8s.utf8Bytes("a\uD83D\uDE00", 5));
+
+        Assert.assertEquals(1, Utf8s.utf8Bytes("\uD83Da", 1));
+        Assert.assertEquals(1, Utf8s.utf8Bytes("\uDE00b", 1));
+        Assert.assertEquals(1, Utf8s.utf8Bytes("a\uD83D", 1));
+        Assert.assertEquals(1, Utf8s.utf8Bytes("a\uDE00", 1));
+    }
+
+    @Test
     public void testUtf8Support() {
         StringBuilder expected = new StringBuilder();
         for (int i = 0; i < 0xD800; i++) {
@@ -269,11 +362,43 @@ public class Utf8sTest {
         }
     }
 
+    private static void assertStrCpyUtf8(long mem, int bufSize, String value, int maxBytes, int expectedBytes, String expected) {
+        final byte sentinel = 0x5A;
+        fill(mem, bufSize, sentinel);
+
+        int n = Utf8s.strCpyUtf8(value, mem, maxBytes);
+        Assert.assertEquals(expectedBytes, n);
+        Assert.assertEquals(expected, readUtf8(mem, n));
+        for (int i = n; i < bufSize; i++) {
+            Assert.assertEquals("write past copied bytes at offset " + i, sentinel, Unsafe.getUnsafe().getByte(mem + i));
+        }
+    }
+
     private static long copyBytes(long buf, byte[] bytes) {
         for (int n = bytes.length, i = 0; i < n; i++) {
             Unsafe.getUnsafe().putByte(buf + i, bytes[i]);
         }
         return buf + bytes.length;
+    }
+
+    private static void assertUntouched(long mem, int bufSize, byte expected) {
+        for (int i = 0; i < bufSize; i++) {
+            Assert.assertEquals("unexpected write at offset " + i, expected, Unsafe.getUnsafe().getByte(mem + i));
+        }
+    }
+
+    private static void fill(long mem, int len, byte value) {
+        for (int i = 0; i < len; i++) {
+            Unsafe.getUnsafe().putByte(mem + i, value);
+        }
+    }
+
+    private static String readUtf8(long mem, int len) {
+        byte[] bytes = new byte[len];
+        for (int i = 0; i < len; i++) {
+            bytes[i] = Unsafe.getUnsafe().getByte(mem + i);
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     private boolean copyToSinkWithTextUtil(StringSink query, String text) {

--- a/core/src/test/java/io/questdb/client/test/std/str/Utf8sTest.java
+++ b/core/src/test/java/io/questdb/client/test/std/str/Utf8sTest.java
@@ -271,6 +271,27 @@ public class Utf8sTest {
     }
 
     @Test
+    public void testStrCpyUtf8FromOffset() {
+        final int bufSize = 64;
+        long mem = Unsafe.malloc(bufSize, MemoryTag.NATIVE_DEFAULT);
+        try {
+            final byte sentinel = 0x5A;
+            String value = "ascii-prefixé世\uD83D\uDE00\uD800x";
+            int lo = "ascii-prefix".length();
+            int expectedBytes = Utf8s.utf8Bytes(value, lo, value.length());
+
+            fill(mem, bufSize, sentinel);
+            Assert.assertEquals(expectedBytes, Utf8s.strCpyUtf8(value, lo, mem, expectedBytes));
+            Assert.assertEquals("é世\uD83D\uDE00?x", readUtf8(mem, expectedBytes));
+            for (int i = expectedBytes; i < bufSize; i++) {
+                Assert.assertEquals("write past copied bytes at offset " + i, sentinel, Unsafe.getUnsafe().getByte(mem + i));
+            }
+        } finally {
+            Unsafe.free(mem, bufSize, MemoryTag.NATIVE_DEFAULT);
+        }
+    }
+
+    @Test
     public void testStrCpyUtf8DoesNotSplitCharactersAtLimit() {
         final int bufSize = 16;
         long mem = Unsafe.malloc(bufSize, MemoryTag.NATIVE_DEFAULT);
@@ -317,6 +338,14 @@ public class Utf8sTest {
         Assert.assertEquals(2, Utf8s.utf8Bytes("\uDE00b"));
         Assert.assertEquals(1, Utf8s.utf8Bytes("\uD83D"));
         Assert.assertEquals(1, Utf8s.utf8Bytes("\uDE00"));
+    }
+
+    @Test
+    public void testUtf8BytesRange() {
+        String value = "xxAé世\uD83D\uDE00yy";
+        Assert.assertEquals(10, Utf8s.utf8Bytes(value, 2, 7));
+        Assert.assertEquals(1, Utf8s.utf8Bytes(value, 5, 6));
+        Assert.assertEquals(4, Utf8s.utf8Bytes(value, 5, 7));
     }
 
     @Test


### PR DESCRIPTION
Improve QWP/WebSocket sender error reporting so failures observed by the I/O thread are surfaced back to the caller instead of getting hidden behind generic queue state errors.

The main user-visible case is an oversized server response frame: callers now get the underlying WebSocket/QWP failure, with actionable context, when they next call into the sender.

Also clarifies the failure contract: after a WebSocket connection is established, send failures, ACK errors, server error ACKs, invalid ACKs, timeouts, or server closes put the sender into a terminal failed state. The sender retains the first failure and rethrows it from subsequent public calls; callers should close it and create a new sender to resume sending.