### PR TITLE
ci(build): switch CI from JDK 17 to GraalVM JDK 25

### DIFF
--- a/.github/workflows/rebuild_native_libs.yml
+++ b/.github/workflows/rebuild_native_libs.yml
@@ -109,11 +109,12 @@ jobs:
           wget -nv https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.tar.gz
           tar -zxf cmake-3.29.2-linux-x86_64.tar.gz
           echo "PATH=`pwd`/cmake-3.29.2-linux-x86_64/bin/:$PATH" >> "$GITHUB_ENV"
-      - name: Install JDK17 (for jni.h)
+      - name: Install GraalVM JDK 25 (for jni.h)
         run: |
-          wget -nv https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.11%2B9/OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz
-          tar xfz OpenJDK17U-jdk_x64_linux_hotspot_17.0.11_9.tar.gz
-          echo "JAVA_HOME=`pwd`/jdk-17.0.11+9/" >> "$GITHUB_ENV"
+          wget -nv -O graalvm.tar.gz https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_linux-x64_bin.tar.gz
+          mkdir graalvm
+          tar xfz graalvm.tar.gz -C graalvm --strip-components=1
+          echo "JAVA_HOME=`pwd`/graalvm" >> "$GITHUB_ENV"
       - name: Generate Makefiles
         run: |
           cd ./core
@@ -144,11 +145,12 @@ jobs:
         run: |
           yum update -y
           yum install wget nasm zstd -y
-      - name: Install JDK17 (for jni.h)
+      - name: Install GraalVM JDK 25 (for jni.h)
         run: |
-          wget -v --timeout=180 https://api.adoptium.net/v3/binary/version/jdk-17.0.11+9/linux/aarch64/jdk/hotspot/normal/eclipse
-          tar xfvz eclipse
-          echo "JAVA_HOME=`pwd`/jdk-17.0.11+9/" >> "$GITHUB_ENV"
+          wget -v --timeout=180 -O graalvm.tar.gz https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_linux-aarch64_bin.tar.gz
+          mkdir graalvm
+          tar xfz graalvm.tar.gz -C graalvm --strip-components=1
+          echo "JAVA_HOME=`pwd`/graalvm" >> "$GITHUB_ENV"
       - name: CMAKE linux-aarch64
         run: |
           cd ./core
@@ -177,10 +179,16 @@ jobs:
           sudo sysctl -w fs.file-max=500000
           sudo apt-get update -y
           sudo apt-get install -y nasm gcc-mingw-w64 g++-mingw-w64
-      - name: Download windows jni_md.h from JDK 11
+      - name: Install GraalVM JDK 25 (for jni.h)
+        run: |
+          wget -nv -O graalvm.tar.gz https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_linux-x64_bin.tar.gz
+          mkdir graalvm
+          tar xfz graalvm.tar.gz -C graalvm --strip-components=1
+          echo "JAVA_HOME=`pwd`/graalvm" >> "$GITHUB_ENV"
+      - name: Download windows jni_md.h from JDK 25
         run: |
           cd core
-          curl https://raw.githubusercontent.com/AdoptOpenJDK/openjdk-jdk11/master/src/java.base/windows/native/include/jni_md.h > $JAVA_HOME/include/jni_md.h
+          curl https://raw.githubusercontent.com/openjdk/jdk25u/master/src/java.base/windows/native/include/jni_md.h > $JAVA_HOME/include/jni_md.h
       - name: CMake Windows
         run: |
           cd core

--- a/ci/run_tests_pipeline.yaml
+++ b/ci/run_tests_pipeline.yaml
@@ -23,6 +23,9 @@ stages:
         pool:
           name: "Azure Pipelines"
           vmImage: "ubuntu-latest"
+        variables:
+          jdkArch: "x64"
+          imageName: "ubuntu-latest"
         steps:
           - checkout: self
             fetchDepth: 0
@@ -33,12 +36,7 @@ stages:
               git checkout FETCH_HEAD
             displayName: "Checkout PR source branch"
             condition: eq(variables['Build.Reason'], 'PullRequest')
-          - task: JavaToolInstaller@0
-            displayName: "Install Java 17"
-            inputs:
-              versionSpec: "17"
-              jdkArchitectureOption: "x64"
-              jdkSourceOption: "PreInstalled"
+          - template: setup.yaml
           - bash: mvn -f core/pom.xml javadoc:javadoc -Pjavadoc --batch-mode
             displayName: "Verify Javadoc"
 

--- a/ci/setup.yaml
+++ b/ci/setup.yaml
@@ -1,10 +1,48 @@
 steps:
-  - task: JavaToolInstaller@0
-    displayName: "Install Java 17"
-    inputs:
-      versionSpec: "17"
-      jdkArchitectureOption: "$(jdkArch)"
-      jdkSourceOption: "PreInstalled"
+  - bash: |
+      set -eux
+      case "$(jdkArch)" in
+        arm64) ARCH="aarch64" ;;
+        *)     ARCH="x64" ;;
+      esac
+      curl -fsSL -o "$HOME/graalvm.tar.gz" \
+        "https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_linux-${ARCH}_bin.tar.gz"
+      mkdir -p "$HOME/graalvm"
+      tar -xzf "$HOME/graalvm.tar.gz" -C "$HOME/graalvm" --strip-components=1
+      echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/graalvm"
+      echo "##vso[task.prependpath]$HOME/graalvm/bin"
+    displayName: "Install GraalVM JDK 25 (Linux)"
+    condition: eq(variables['Agent.OS'], 'Linux')
+
+  - bash: |
+      set -eux
+      case "$(jdkArch)" in
+        arm64) ARCH="aarch64" ;;
+        *)     ARCH="x64" ;;
+      esac
+      curl -fsSL -o "$HOME/graalvm.tar.gz" \
+        "https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_macos-${ARCH}_bin.tar.gz"
+      mkdir -p "$HOME/graalvm"
+      tar -xzf "$HOME/graalvm.tar.gz" -C "$HOME/graalvm" --strip-components=1
+      echo "##vso[task.setvariable variable=JAVA_HOME]$HOME/graalvm/Contents/Home"
+      echo "##vso[task.prependpath]$HOME/graalvm/Contents/Home/bin"
+    displayName: "Install GraalVM JDK 25 (macOS)"
+    condition: eq(variables['Agent.OS'], 'Darwin')
+
+  - powershell: |
+      $ErrorActionPreference = "Stop"
+      $url = "https://download.oracle.com/graalvm/25/latest/graalvm-jdk-25_windows-x64_bin.zip"
+      $zip = Join-Path $env:USERPROFILE "graalvm.zip"
+      $dest = Join-Path $env:USERPROFILE "graalvm"
+      Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing
+      if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+      Expand-Archive -Path $zip -DestinationPath $dest -Force
+      $jdkDir = Get-ChildItem -Path $dest -Directory | Select-Object -First 1
+      $javaHome = $jdkDir.FullName
+      Write-Host "##vso[task.setvariable variable=JAVA_HOME]$javaHome"
+      Write-Host "##vso[task.prependpath]$javaHome\bin"
+    displayName: "Install GraalVM JDK 25 (Windows)"
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
 
   - bash: sudo sysctl -w fs.file-max=500000
     displayName: "Increase file count on Linux"


### PR DESCRIPTION
## Summary

Bumps the JDK used across all CI jobs from Temurin JDK 17 to **Oracle GraalVM JDK 25** (latest). The Java source/target level (`<javac.target>11</javac.target>`) is unchanged — only the build/test toolchain moves.

### Files changed

- **`ci/setup.yaml`** — replaces the `JavaToolInstaller@0` step with platform-conditional GraalVM 25 download steps for Linux, macOS (x64 + arm64) and Windows. Sets `JAVA_HOME` via `##vso[task.setvariable]` and prepends `bin` to `PATH`, so existing `Maven@3` steps using `jdkVersionOption: "default"` pick it up.
- **`ci/run_tests_pipeline.yaml`** — the Javadoc validation job now consumes the `setup.yaml` template instead of inlining its own `JavaToolInstaller`. Added `jdkArch`/`imageName` job variables so the template's conditions resolve.
- **`.github/workflows/rebuild_native_libs.yml`** — both Linux native-build jobs (x86_64 manylinux2014, aarch64 manylinux_2_28) now fetch GraalVM 25 for `jni.h`. The Windows cross-compile job also installs GraalVM 25 and now pulls Windows-specific `jni_md.h` from `openjdk/jdk25u`. The macOS native-build jobs were left alone — they never installed a JDK explicitly and rely on the runner's pre-installed one.

### Notes / trade-offs

- URLs use Oracle's `…/graalvm/25/latest/…` pattern, which is **mutable**. If you'd prefer reproducible pins, swap in versioned URLs like `https://download.oracle.com/graalvm/25/archive/graalvm-jdk-25.0.x_<os>-<arch>_bin.<ext>`.
- Oracle GraalVM ships under the GFTC license (free for production use). If GraalVM CE (GPLv2+CPE) is preferred, the URL pattern changes to the `graalvm/graalvm-ce-builds` GitHub releases.
- `manylinux2014` (CentOS 7 / glibc 2.17) is older than what Oracle GraalVM 25 binaries officially target. This workflow only **reads `include/jni.h`** from the tarball — it never executes Java — so extraction is what matters and that works regardless of glibc.

## Test plan

- [ ] Azure Pipelines `BuildAndTest` stage passes on linux-x64, mac-aarch64, mac-x64, windows-msvc-2022-x64
- [ ] Azure Pipelines `Validate` (Javadoc) job passes
- [ ] Azure Pipelines `Coverage` stage passes
- [ ] Manually trigger `rebuild_native_libs.yml` on this branch and confirm linux-x86_64, linux-aarch64 and windows cross-compile jobs all build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)