### PR TITLE
build: 1.2.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@
         <jmh.version>1.37</jmh.version>
     </properties>
 
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
     <groupId>org.questdb</groupId>
     <artifactId>questdb-client</artifactId>
     <packaging>jar</packaging>
@@ -63,7 +63,7 @@
     <scm>
         <url>scm:git:https://github.com/questdb/java-questdb-client.git</url>
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
-        <tag>HEAD</tag>
+        <tag>1.2.1</tag>
     </scm>
 
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@
         <jmh.version>1.37</jmh.version>
     </properties>
 
-    <version>1.2.1</version>
+    <version>1.2.2-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
     <artifactId>questdb-client</artifactId>
     <packaging>jar</packaging>
@@ -63,7 +63,7 @@
     <scm>
         <url>scm:git:https://github.com/questdb/java-questdb-client.git</url>
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
-        <tag>1.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.questdb</groupId>
     <artifactId>client-examples</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2-SNAPSHOT</version>
     <name>Examples for QuestDB</name>
 
     <dependencies>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>org.questdb</groupId>
     <artifactId>client-examples</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
     <name>Examples for QuestDB</name>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.1</version>
     <groupId>org.questdb</groupId>
     <artifactId>client-parent</artifactId>
     <packaging>pom</packaging>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
         <developerConnection>scm:git:https://github.com/questdb/java-questdb-client.git</developerConnection>
         <url>https://github.com/questdb/java-questdb-client</url>
-        <tag>HEAD</tag>
+        <tag>1.2.1</tag>
     </scm>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <version>1.2.1</version>
+    <version>1.2.2-SNAPSHOT</version>
     <groupId>org.questdb</groupId>
     <artifactId>client-parent</artifactId>
     <packaging>pom</packaging>
@@ -35,7 +35,7 @@
         <connection>scm:git:https://github.com/questdb/java-questdb-client.git</connection>
         <developerConnection>scm:git:https://github.com/questdb/java-questdb-client.git</developerConnection>
         <url>https://github.com/questdb/java-questdb-client</url>
-        <tag>1.2.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <build>


### PR DESCRIPTION
## Summary
- Standard `maven-release-plugin` commits for the 1.2.1 release: tag the release, then advance development to `1.2.2-SNAPSHOT`.
- Tag `1.2.1` is already published on origin (points at `99d3a0d`).
- Net diff against `main` is the version bump in the three `pom.xml` files (`1.2.1-SNAPSHOT` → `1.2.2-SNAPSHOT`).

## Test plan
- [x] CI green on the branch
- [x] Confirm `1.2.1` artifact is published to Maven Central
- [x] `mvn -pl core help:evaluate -Dexpression=project.version -q -DforceStdout` reports `1.2.2-SNAPSHOT` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)