### PR TITLE
chore(build): allow Maven release without GPG passphrase

### DIFF
--- a/.github/workflows/maven_central_release.yml
+++ b/.github/workflows/maven_central_release.yml
@@ -90,7 +90,6 @@ jobs:
         run: |
           required_vars=(
             MAVEN_GPG_PRIVATE_KEY
-            MAVEN_GPG_PASSPHRASE
             MAVEN_CENTRAL_USERNAME
             MAVEN_CENTRAL_PASSWORD
           )
@@ -104,6 +103,9 @@ jobs:
 
       - name: Configure Maven settings.xml
         run: |
+          if [[ -z "${MAVEN_GPG_PASSPHRASE+x}" ]]; then
+            echo "MAVEN_GPG_PASSPHRASE=" >> "$GITHUB_ENV"
+          fi
           mkdir -p "$HOME/.m2"
           cat > "$HOME/.m2/settings.xml" <<'EOF'
           <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"


### PR DESCRIPTION
## Summary
- make MAVEN_GPG_PASSPHRASE optional for Maven Central releases
- only add the gpg.passphrase Maven server entry when the secret value is present
- keep existing AWS secret storage and password-protected key support unchanged

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/maven_central_release.yml"); puts "workflow yaml ok"'
- git diff --check
- mvn -B -q -N -DforceStdout help:evaluate -Dexpression=project.version