### PR TITLE
fix(qwp): fix ingestion stalls after append failures and on sender startup

### DIFF
--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/QwpWebSocketSender.java
@@ -3072,6 +3072,18 @@ public class QwpWebSocketSender implements Sender {
             cursorEngine.appendBlocking(toSend.getBufferPtr(), toSend.getBufferPos());
             toSend.markRecycled();
         } catch (Throwable t) {
+            // appendBlocking failed synchronously on the user thread — the
+            // payload never reached the engine, so no I/O thread will
+            // recycle toSend. Recycle it here so a later flush can swap
+            // back to it; flushPendingRows aborts its post-enqueue state
+            // updates after this throw, so the source rows and the
+            // sent-schema watermark stay intact and the next batch re-emits
+            // the same rows along with the full schema + symbol-dict delta.
+            if (toSend.isSending()) {
+                toSend.markRecycled();
+            } else if (toSend.isSealed()) {
+                toSend.rollbackSealForRetry();
+            }
             // Surface any I/O thread error first — appendBlocking itself only
             // throws on PAYLOAD_TOO_LARGE / backpressure deadline, but the
             // I/O loop can have failed independently.

--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/sf/cursor/SegmentManager.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/sf/cursor/SegmentManager.java
@@ -247,6 +247,17 @@ public final class SegmentManager implements QuietCloseable {
             }
         }
         ring.setManagerWakeup(this::wakeWorker);
+        // Nudge the worker so it picks up the new ring on its very next
+        // iteration. Without this, register-after-start has a race window:
+        // start() schedules the worker thread, and if that thread reaches
+        // workerLoop and takes `lock` before this method does, it observes
+        // an empty `rings` snapshot, services nothing, then parkNanos
+        // (potentially seconds). A new ring whose first append does not
+        // cross the high-water mark fires no producer-side wakeup either,
+        // leaving the ring without a spare for the full poll interval.
+        // wakeWorker is cheap (a single LockSupport.unpark) and a no-op
+        // when the worker has not been started yet.
+        wakeWorker();
     }
 
     public synchronized void start() {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderTest.java
@@ -27,17 +27,22 @@ package io.questdb.client.test.cutlass.qwp.client;
 import io.questdb.client.cutlass.line.LineSenderException;
 import io.questdb.client.cutlass.line.array.DoubleArray;
 import io.questdb.client.cutlass.line.array.LongArray;
+import io.questdb.client.cutlass.qwp.client.MicrobatchBuffer;
 import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
+import io.questdb.client.cutlass.qwp.client.sf.cursor.CursorSendEngine;
 import io.questdb.client.cutlass.qwp.protocol.QwpTableBuffer;
 import io.questdb.client.std.Decimal128;
 import io.questdb.client.std.Decimal256;
 import io.questdb.client.std.Decimal64;
 import io.questdb.client.std.bytes.DirectByteSlice;
+import io.questdb.client.test.cutlass.qwp.websocket.TestWebSocketServer;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
 
 import static io.questdb.client.test.tools.TestUtils.assertMemoryLeak;
 
@@ -322,6 +327,54 @@ public class QwpWebSocketSenderTest {
                 Assert.fail("Expected LineSenderException");
             } catch (LineSenderException e) {
                 Assert.assertTrue(e.getMessage().contains("closed"));
+            }
+        });
+    }
+
+    @Test
+    public void testFlushAppendFailureDoesNotLeaveMicrobatchBufferInUse() throws Exception {
+        assertMemoryLeak(() -> {
+            int port = TestPorts.findUnusedPort();
+            try (TestWebSocketServer server = new TestWebSocketServer(port, new TestWebSocketServer.WebSocketServerHandler() {
+            })) {
+                server.start();
+                Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
+
+                // Memory-only engine with a 33-byte budget and a 1 ns append
+                // deadline guarantees every appendBlocking() call trips the
+                // backpressure deadline and throws.
+                CursorSendEngine engine = new CursorSendEngine(null, 33, 33, 1L);
+                QwpWebSocketSender sender = QwpWebSocketSender.connect(
+                        "localhost", port, null, Integer.MAX_VALUE, 0, 0L, null,
+                        QwpWebSocketSender.DEFAULT_MAX_SCHEMAS_PER_CONNECTION, false, engine, 0L);
+                try {
+                    sender.table("t").longColumn("v", 1L).atNow();
+
+                    try {
+                        sender.flushAndGetSequence();
+                        Assert.fail("Expected LineSenderException");
+                    } catch (LineSenderException e) {
+                        Assert.assertTrue(e.getMessage().contains("cursor SF append failed"));
+                    }
+
+                    MicrobatchBuffer buffer0 = getMicrobatchBuffer(sender, "buffer0");
+                    MicrobatchBuffer buffer1 = getMicrobatchBuffer(sender, "buffer1");
+                    Assert.assertFalse(
+                            "failed append must not leave any buffer in use [buffer0="
+                                    + MicrobatchBuffer.stateName(buffer0.getState())
+                                    + ", buffer1=" + MicrobatchBuffer.stateName(buffer1.getState()) + "]",
+                            buffer0.isInUse() || buffer1.isInUse());
+                } finally {
+                    // close() drains pending rows, which appendBlocking still
+                    // rejects because the engine is permanently wedged in this
+                    // test. The bug under test is about microbatch buffer
+                    // state, not about close() being lenient toward residual
+                    // unflushed rows — swallow the predictable rethrow here.
+                    try {
+                        sender.close();
+                    } catch (LineSenderException ignored) {
+                    }
+                }
             }
         });
     }
@@ -703,6 +756,12 @@ public class QwpWebSocketSenderTest {
                     "expected message to mention 'closed', got: " + e.getMessage(),
                     e.getMessage() != null && e.getMessage().contains("closed"));
         }
+    }
+
+    private static MicrobatchBuffer getMicrobatchBuffer(QwpWebSocketSender sender, String fieldName) throws Exception {
+        Field field = QwpWebSocketSender.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (MicrobatchBuffer) field.get(sender);
     }
 
     /**

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SegmentManagerTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SegmentManagerTest.java
@@ -218,18 +218,20 @@ public class SegmentManagerTest {
         TestUtils.assertMemoryLeak(() -> {
             // pollNanos is intentionally long enough that the 5s park can be
             // ruled out as the mechanism by which the first spare arrives.
-            // The worker thread enters workerLoop on start(), takes the lock,
-            // sees the just-registered ring with needsHotSpare()==true, and
-            // provisions the spare BEFORE parking. The spare must therefore
-            // land within seconds of register(), not minutes -- the 5s park is
-            // never reached on the first iteration.
+            // register() unparks the worker after publishing the new ring,
+            // so the worker re-iterates and provisions the spare even when
+            // its first loop snapshot ran before register() acquired `lock`.
+            // The spare must therefore land within seconds of register(),
+            // not minutes -- the 5s park is never reached.
             //
             // The append below is incidental to the contract under test; it
             // does NOT cross the SegmentRing high-water mark for this 4-frame
             // segment (HEADER_SIZE 24 + FRAME_HEADER_SIZE 8 + 16 = 48 vs
             // signalAtBytes = (120 >> 2) * 3 = 90), so no producer-side wakeup
             // fires. The rotation/high-water wakeup paths are covered by
-            // testRotationWakeupTriggersImmediateSparePrep.
+            // testRotationWakeupTriggersImmediateSparePrep, and the
+            // deterministic register-after-park case is covered by
+            // testRegisterAfterWorkerParkedWakesWorker.
             long pollNanos = 5_000_000_000L; // 5 seconds
             long segSize = MmapSegment.HEADER_SIZE
                     + 4 * (MmapSegment.FRAME_HEADER_SIZE + 16);
@@ -252,6 +254,40 @@ public class SegmentManagerTest {
                         elapsedMs < 4000);
             } finally {
                 Unsafe.free(buf, 16, MemoryTag.NATIVE_DEFAULT);
+            }
+        });
+    }
+
+    @Test
+    public void testRegisterAfterWorkerParkedWakesWorker() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            // Deterministic version of testFirstSpareLandsBeforeFirstPoll:
+            // sleep between start() and register() long enough for the worker
+            // to definitely complete its first (empty) iteration and enter
+            // parkNanos. Without register()'s wakeWorker() the spare would
+            // not land for the full 5s poll interval; with it the spare lands
+            // promptly because register() unparks the worker out of its park.
+            // No append at all, so no producer-side wakeup can mask a missing
+            // register-side wakeup.
+            long pollNanos = 5_000_000_000L; // 5 seconds
+            long segSize = MmapSegment.HEADER_SIZE
+                    + 4 * (MmapSegment.FRAME_HEADER_SIZE + 16);
+            MmapSegment seg0 = MmapSegment.create(tmpDir + "/0000000000000000.sfa", 0, segSize);
+            try (SegmentRing ring = new SegmentRing(seg0, segSize);
+                 SegmentManager mgr = new SegmentManager(segSize, pollNanos)) {
+                mgr.start();
+                // Give the worker plenty of time to enter workerLoop, snapshot
+                // an empty rings list, and reach parkNanos. 250ms is far more
+                // than the OS scheduling + thread startup cost on any sane
+                // CI runner, and still well below the 5s poll interval.
+                Thread.sleep(250);
+                long t0 = System.nanoTime();
+                mgr.register(ring, tmpDir);
+                assertTrue("register must wake a worker that has already parked",
+                        waitFor(() -> !ring.needsHotSpare(), 2000));
+                long elapsedMs = (System.nanoTime() - t0) / 1_000_000L;
+                assertTrue("spare arrived in " + elapsedMs + "ms -- should be <<5000ms",
+                        elapsedMs < 4000);
             }
         });
     }


### PR DESCRIPTION
Refs questdb/questdb#7143

This PR bundles two QWP fixes for the upcoming 1.3.1 client release. Both are small, localized, and validated by their own regression tests.

## Microbatch buffer release on append failure

- `QwpWebSocketSender.sealAndSwapBuffer()` left the microbatch buffer in `SENDING` state when `CursorSendEngine.appendBlocking()` threw. No I/O thread ever recycles a buffer the engine never accepted, so the next flush would wait 30 s on the recycle latch and then throw `Timeout waiting for buffer to be recycled`.
- The catch block now puts the buffer back into a non-in-use state on the user thread before rethrowing: `markRecycled()` from `SENDING`, `rollbackSealForRetry()` from `SEALED`.
- The encoded payload itself is dropped, but `flushPendingRows()` aborts its post-enqueue state updates after `sealAndSwapBuffer()` throws, so the source rows in `tableBuffers` and the sent-schema watermark stay intact. The next batch re-emits the same rows together with the full schema and symbol-dict delta — matching the existing "self-sufficient frames" invariant the cursor SF pipeline already relies on.

## Segment manager wakeup on register

- `SegmentManager.register()` now unparks the worker after publishing the new ring. Without the wakeup, if the worker thread acquires the manager lock before `register()` does, it snapshots an empty `rings`, services nothing, and parks for the full poll interval. A ring whose first append does not cross the high-water mark fires no producer-side wakeup either, so the spare never lands until the poll expires.
- The race is pre-existing in the store-and-forward code, latent since the SF feature first landed. It surfaced on the parent-repo CI run only because the mac-other + JaCoCo combination consistently scheduled the worker first; the prior fix (commit 19c5c65) widened the test budget to 2 s but the poll interval is 5 s, so no budget below 5 s could rescue that ordering.
- The fix is one call to `wakeWorker()` after `setManagerWakeup()`. `LockSupport.unpark` is cheap, is a no-op when the worker has not been started, and grants a permit that the next `parkNanos` consumes immediately — both interleavings are covered.

## Tradeoffs

- The microbatch-buffer fix's `close()`-after-failed-flush retries the drain. If the underlying engine is still wedged (e.g. permanent backpressure, like the deliberately-undersized engine in the new test), that retry fails again and surfaces as a separate `LineSenderException`. The test acknowledges this and swallows the close-time rethrow. Real-world transient backpressure is expected to clear between the user's flush call and `close()`, in which case the drain succeeds.
- The segment-manager fix bundles a second unrelated change under a title that names only the microbatch fix. The release-note line for 1.3.1 will undercount the actual scope. Mitigated by clearly separating the two fixes in this description and in the commit history (two separate commits).
- No state-machine extension on either fix: `MicrobatchBuffer.markRecycled()` / `rollbackSealForRetry()` and `SegmentManager.wakeWorker()` already existed.

## Test plan

- New `QwpWebSocketSenderTest.testFlushAppendFailureDoesNotLeaveMicrobatchBufferInUse` (the reproducer from questdb/questdb#7143). Fails on `main` with `buffer0=SENDING, buffer1=FILLING` and the 30 s recycle-timeout suppressed exception; passes in ~80 ms with this change.
- New `SegmentManagerTest.testRegisterAfterWorkerParkedWakesWorker`. Sleeps 250 ms between `start()` and `register()` to guarantee the worker has parked on an empty `rings` snapshot, then asserts the spare lands within 2 s. Without the `wakeWorker()` call this test fails reliably; with it, all 9 `SegmentManagerTest` cases pass.
- Full `QwpWebSocketSenderTest` and the broader QWP client suite still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)