### PR TITLE
test(qwp): fix flaky port-bind race in WebSocket client tests

### DIFF
--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CleanShutdownNoReplayTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CleanShutdownNoReplayTest.java
@@ -73,12 +73,12 @@ public class CleanShutdownNoReplayTest {
         // Phase 1: server ACKs every frame. Sender writes a few rows,
         // flushes, then close() blocks for the default 5s drain — by the
         // time close returns, every frame has been ACK'd.
-        int port1 = TestPorts.findUnusedPort();
         AckHandler ack1 = new AckHandler();
-        try (TestWebSocketServer s1 = new TestWebSocketServer(port1, ack1)) {
+        try (TestWebSocketServer s1 = new TestWebSocketServer(ack1)) {
             s1.start();
             Assert.assertTrue(s1.awaitStart(5, TimeUnit.SECONDS));
 
+            int port1 = s1.getPort();
             String cfg1 = "ws::addr=localhost:" + port1
                     + ";sf_dir=" + sfDir + ";";
             try (Sender sender = Sender.fromConfig(cfg1)) {
@@ -105,12 +105,12 @@ public class CleanShutdownNoReplayTest {
         // SAME slot dir. There is no unacked work — both rings should agree
         // there's nothing to send. The expected count of binary frames at
         // server 2 is zero.
-        int port2 = port1 + 50;
         AckHandler ack2 = new AckHandler();
-        try (TestWebSocketServer s2 = new TestWebSocketServer(port2, ack2)) {
+        try (TestWebSocketServer s2 = new TestWebSocketServer(ack2)) {
             s2.start();
             Assert.assertTrue(s2.awaitStart(5, TimeUnit.SECONDS));
 
+            int port2 = s2.getPort();
             String cfg2 = "ws::addr=localhost:" + port2
                     + ";sf_dir=" + sfDir + ";";
             try (Sender ignored = Sender.fromConfig(cfg2)) {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainDoubleSignalTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainDoubleSignalTest.java
@@ -103,12 +103,12 @@ public class CloseDrainDoubleSignalTest {
 
     @Test(timeout = 30_000)
     public void testCloseDoesNotDoubleSignalWhenAsyncHandlerOwnsErrorAndDrainRuns() throws Exception {
-        int port = TestPorts.findUnusedPort();
         GatedHaltHandler server = new GatedHaltHandler();
-        try (TestWebSocketServer ws = new TestWebSocketServer(port, server)) {
+        try (TestWebSocketServer ws = new TestWebSocketServer(server)) {
             ws.start();
             Assert.assertTrue(ws.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = ws.getPort();
             // Memory mode + a positive drain timeout: drainOnClose() WILL run.
             String cfg = "ws::addr=localhost:" + port
                     + ";close_flush_timeout_millis=2000;";

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainTest.java
@@ -225,13 +225,13 @@ public class CloseDrainTest {
      */
     @Test
     public void testDrainAfterFlushWaitsForPriorUnackedFrames() throws Exception {
-        int port = TestPorts.findUnusedPort();
         long ackDelayMs = 600;
         DelayingAckHandler handler = new DelayingAckHandler(ackDelayMs);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port + ";";
             try (Sender sender = Sender.fromConfig(cfg)) {
                 sender.table("foo").longColumn("v", 1L).atNow();

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainTest.java
@@ -54,13 +54,13 @@ public class CloseDrainTest {
         // Server delays every ACK by 800ms. With the default
         // close_flush_timeout_millis=60000, close() must wait for that
         // ACK before returning. Pre-fix close() returned within milliseconds.
-        int port = TestPorts.findUnusedPort();
         long ackDelayMs = 800;
         DelayingAckHandler handler = new DelayingAckHandler(ackDelayMs);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port + ";";  // memory mode
             long elapsedMs;
             try (Sender sender = Sender.fromConfig(cfg)) {
@@ -82,13 +82,13 @@ public class CloseDrainTest {
         // Same delayed-ACK server, but with close_flush_timeout_millis=0
         // (fast close). close() must return immediately, well before the
         // ACK delay would have elapsed.
-        int port = TestPorts.findUnusedPort();
         long ackDelayMs = 1500;
         DelayingAckHandler handler = new DelayingAckHandler(ackDelayMs);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + ";close_flush_timeout_millis=0;";
             long elapsedMs;
@@ -115,13 +115,13 @@ public class CloseDrainTest {
         // sentinel in LineSenderBuilder, so the build path silently substitutes
         // DEFAULT_CLOSE_FLUSH_TIMEOUT_MILLIS (60s) and close() blocks for the
         // full ACK delay instead of returning fast.
-        int port = TestPorts.findUnusedPort();
         long ackDelayMs = 1500;
         DelayingAckHandler handler = new DelayingAckHandler(ackDelayMs);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + ";close_flush_timeout_millis=-1;";
             long elapsedMs;
@@ -144,13 +144,13 @@ public class CloseDrainTest {
         // Server that buffers frames silently and never ACKs. close() must
         // throw a drain-timeout LineSenderException after roughly the
         // configured timeout — not hang forever and not return immediately.
-        int port = TestPorts.findUnusedPort();
         long timeoutMs = 500;
         SilentHandler handler = new SilentHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + ";close_flush_timeout_millis=" + timeoutMs + ";";
             long elapsedMs;
@@ -182,13 +182,13 @@ public class CloseDrainTest {
         // testCloseBlocksUntilAckArrives, but the wait happens inside the
         // explicit drain() call. The subsequent close() should be a near-
         // instant no-op because everything is already acked.
-        int port = TestPorts.findUnusedPort();
         long ackDelayMs = 600;
         DelayingAckHandler handler = new DelayingAckHandler(ackDelayMs);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port + ";";
             try (Sender sender = Sender.fromConfig(cfg)) {
                 sender.table("foo").longColumn("v", 1L).atNow();
@@ -218,12 +218,12 @@ public class CloseDrainTest {
         // usable for further row writes after a false return; the
         // outstanding frames remain pending and close()'s own drain still
         // runs.
-        int port = TestPorts.findUnusedPort();
         SilentHandler handler = new SilentHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port + ";close_flush_timeout_millis=0;";
             try (Sender sender = Sender.fromConfig(cfg)) {
                 sender.table("foo").longColumn("v", 1L).atNow();
@@ -246,12 +246,12 @@ public class CloseDrainTest {
         // Fast server: every frame is acked promptly. drain(longTimeout)
         // must return true quickly -- no spurious wait when there is
         // nothing to wait for.
-        int port = TestPorts.findUnusedPort();
         DelayingAckHandler handler = new DelayingAckHandler(0);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port + ";";
             try (Sender sender = Sender.fromConfig(cfg)) {
                 sender.table("foo").longColumn("v", 1L).atNow();
@@ -266,9 +266,9 @@ public class CloseDrainTest {
 
     @Test
     public void testAsyncCloseDrainSucceedsWhenServerStartsDuringDrain() throws Exception {
-        int port = TestPorts.findUnusedPort();
         DelayingAckHandler handler = new DelayingAckHandler(0);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + sfDirOpt()
                     + ";initial_connect_retry=async"
@@ -303,12 +303,12 @@ public class CloseDrainTest {
 
     @Test
     public void testAsyncCloseDrainSucceedsWhenServerWasUpAllAlong() throws Exception {
-        int port = TestPorts.findUnusedPort();
         DelayingAckHandler handler = new DelayingAckHandler(0);
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             for (int i = 0; i < 20; i++) {
                 String cfg = "ws::addr=localhost:" + port
                         + sfDirOpt()

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseTerminalConflationTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseTerminalConflationTest.java
@@ -71,12 +71,12 @@ public class CloseTerminalConflationTest {
 
     @Test(timeout = 30_000)
     public void testCloseSurfacesHaltAfterEarlierDropFlippedTheStickyFlag() throws Exception {
-        int port = TestPorts.findUnusedPort();
         DropThenGatedHaltHandler server = new DropThenGatedHaltHandler();
-        try (TestWebSocketServer ws = new TestWebSocketServer(port, server)) {
+        try (TestWebSocketServer ws = new TestWebSocketServer(server)) {
             ws.start();
             Assert.assertTrue(ws.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = ws.getPort();
             // Memory mode + a positive drain timeout: drainOnClose() WILL run.
             String cfg = "ws::addr=localhost:" + port
                     + ";close_flush_timeout_millis=2000;";

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/InitialConnectAsyncTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/InitialConnectAsyncTest.java
@@ -60,9 +60,9 @@ public class InitialConnectAsyncTest {
         // Server returns HTTP 401 on every upgrade attempt. Auth failures
         // are terminal at the I/O thread; in async mode they are
         // delivered as a SenderError, not thrown from fromConfig.
-        int port = TestPorts.findUnusedPort();
-        try (Always401Fixture fixture = new Always401Fixture(port)) {
+        try (Always401Fixture fixture = new Always401Fixture()) {
             fixture.start();
+            int port = fixture.getPort();
             ErrorInbox inbox = new ErrorInbox();
             String cfg = "ws::addr=localhost:" + port
                     + sfDirOpt() + ";initial_connect_retry=async"
@@ -159,9 +159,9 @@ public class InitialConnectAsyncTest {
         // appended to the cursor SF engine on the producer thread. The
         // I/O thread retries connect in the background; once the server
         // comes up, the buffered frame is sent and ACKed.
-        int port = TestPorts.findUnusedPort();
         AckHandler handler = new AckHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + sfDirOpt() + ";initial_connect_retry=async"
                     + ";reconnect_max_duration_millis=10000"
@@ -239,9 +239,9 @@ public class InitialConnectAsyncTest {
         // Because the loop did connect at least once before the outage,
         // the SenderError must use the connection-lost tag and the sender
         // must report wasEverConnected()==true.
-        int port = TestPorts.findUnusedPort();
         AckHandler handler = new AckHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, java.util.concurrent.TimeUnit.SECONDS));
 
@@ -299,8 +299,8 @@ public class InitialConnectAsyncTest {
         // caller — there is no observable "never connected" window in
         // those modes, so misclassifying a budget exhaustion as
         // never-connected is impossible.
-        int port = TestPorts.findUnusedPort();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, new AckHandler())) {
+        try (TestWebSocketServer server = new TestWebSocketServer(new AckHandler())) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, java.util.concurrent.TimeUnit.SECONDS));
             String cfg = "ws::addr=localhost:" + port
@@ -446,8 +446,16 @@ public class InitialConnectAsyncTest {
         private Thread acceptThread;
         private volatile boolean running;
 
-        Always401Fixture(int port) throws IOException {
-            this.serverSocket = new ServerSocket(port);
+        Always401Fixture() throws IOException {
+            // Bind the listener up front on an OS-assigned loopback port and
+            // hold it for the fixture's lifetime; read it back via getPort().
+            // Owning the port from allocation to teardown avoids the bind race
+            // a pre-selected port would carry.
+            this.serverSocket = new ServerSocket(0, 50, java.net.InetAddress.getLoopbackAddress());
+        }
+
+        int getPort() {
+            return serverSocket.getLocalPort();
         }
 
         @Override

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/InitialConnectRetryTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/InitialConnectRetryTest.java
@@ -100,14 +100,14 @@ public class InitialConnectRetryTest {
     }
 
     @Test
-    public void testWithRetrySucceedsWhenServerComesUpInTime() {
+    public void testWithRetrySucceedsWhenServerComesUpInTime() throws Exception {
         // initial_connect_retry=true; we open the sender BEFORE starting
         // the server, then start the server in a background thread after
         // a short delay. The retry loop should see the server come up and
         // proceed cleanly.
-        int port = TestPorts.findUnusedPort();
         AckHandler handler = new AckHandler();
-        TestWebSocketServer server = new TestWebSocketServer(port, handler);
+        TestWebSocketServer server = new TestWebSocketServer(handler);
+        int port = server.getPort();
         Thread starter = new Thread(() -> {
             try {
                 Thread.sleep(300);

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/IoThreadErrorSurfacedOnRowApiTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/IoThreadErrorSurfacedOnRowApiTest.java
@@ -64,9 +64,9 @@ public class IoThreadErrorSurfacedOnRowApiTest {
 
     @Test
     public void testRowApiMethodSurfacesIoThreadTerminalError() throws Exception {
-        int port = TestPorts.findUnusedPort();
         ErrorAckHandler handler = new ErrorAckHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/PrReviewRedTestsE2e.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/PrReviewRedTestsE2e.java
@@ -78,13 +78,13 @@ public class PrReviewRedTestsE2e {
     @Test
     public void testC4_handlerMustObserveTerminalErrorWhenInvoked() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             int iterations = 30;
             AtomicInteger nullObservations = new AtomicInteger();
             AtomicInteger totalObservations = new AtomicInteger();
 
             ParseErrorAckHandler serverHandler = new ParseErrorAckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, serverHandler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(serverHandler)) {
+                int port = server.getPort();
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
@@ -161,9 +161,9 @@ public class PrReviewRedTestsE2e {
     @Test
     public void testC11_postHaltFlushThrowsTypedLineSenderServerException() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             ParseErrorAckHandler serverHandler = new ParseErrorAckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, serverHandler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(serverHandler)) {
+                int port = server.getPort();
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpQueryClientWalkTrackerTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpQueryClientWalkTrackerTest.java
@@ -76,12 +76,12 @@ public class QwpQueryClientWalkTrackerTest {
         // 404 (per failover.md §4.1: a single mid-deploy node serving the
         // wrong path while peers are healthy is a routing glitch, not an
         // auth failure). Walk must continue.
-        int port404 = TestPorts.findUnusedPort();
-        int portOk = TestPorts.findUnusedPort();
-        TestWebSocketServer notFound = new TestWebSocketServer(port404, NOOP_HANDLER);
+        TestWebSocketServer notFound = new TestWebSocketServer(NOOP_HANDLER);
         notFound.setRejectWithStatus(404, "Not Found");
-        TestWebSocketServer ok = new TestWebSocketServer(portOk, NOOP_HANDLER);
+        int port404 = notFound.getPort();
+        TestWebSocketServer ok = new TestWebSocketServer(NOOP_HANDLER);
         ok.setSendServerInfo(true);
+        int portOk = ok.getPort();
         try {
             notFound.start();
             ok.start();
@@ -103,12 +103,12 @@ public class QwpQueryClientWalkTrackerTest {
     public void testWalk_426UpgradeRequiredIsTransportNotTerminal() throws Exception {
         // 426 Upgrade Required is per failover.md §6 a transient/transport
         // failure (NOT terminal). The walk must continue to the next host.
-        int port426 = TestPorts.findUnusedPort();
-        int portOk = TestPorts.findUnusedPort();
-        TestWebSocketServer rejecting = new TestWebSocketServer(port426, NOOP_HANDLER);
+        TestWebSocketServer rejecting = new TestWebSocketServer(NOOP_HANDLER);
         rejecting.setRejectWithStatus(426, "Upgrade Required");
-        TestWebSocketServer ok = new TestWebSocketServer(portOk, NOOP_HANDLER);
+        int port426 = rejecting.getPort();
+        TestWebSocketServer ok = new TestWebSocketServer(NOOP_HANDLER);
         ok.setSendServerInfo(true);
+        int portOk = ok.getPort();
         try {
             rejecting.start();
             ok.start();
@@ -133,12 +133,12 @@ public class QwpQueryClientWalkTrackerTest {
         // TopologyRejects from prior outages -- here there are none),
         // exhausts again, and surfaces QwpRoleMismatchException with the
         // last observed role attached.
-        int port1 = TestPorts.findUnusedPort();
-        int port2 = TestPorts.findUnusedPort();
-        TestWebSocketServer rep1 = new TestWebSocketServer(port1, NOOP_HANDLER);
+        TestWebSocketServer rep1 = new TestWebSocketServer(NOOP_HANDLER);
         rep1.setRejectWithRole("REPLICA");
-        TestWebSocketServer rep2 = new TestWebSocketServer(port2, NOOP_HANDLER);
+        int port1 = rep1.getPort();
+        TestWebSocketServer rep2 = new TestWebSocketServer(NOOP_HANDLER);
         rep2.setRejectWithRole("REPLICA");
+        int port2 = rep2.getPort();
         try {
             rep1.start();
             rep2.start();
@@ -187,11 +187,11 @@ public class QwpQueryClientWalkTrackerTest {
     @Test
     public void testWalk_AuthFailure403IsTerminal() throws Exception {
         // 403 is symmetric to 401: same terminal classification.
-        int port403 = TestPorts.findUnusedPort();
-        int portOk = TestPorts.findUnusedPort();
-        TestWebSocketServer forbidden = new TestWebSocketServer(port403, NOOP_HANDLER);
+        TestWebSocketServer forbidden = new TestWebSocketServer(NOOP_HANDLER);
         forbidden.setRejectWithStatus(403, "Forbidden");
-        TestWebSocketServer ok = new TestWebSocketServer(portOk, NOOP_HANDLER);
+        int port403 = forbidden.getPort();
+        TestWebSocketServer ok = new TestWebSocketServer(NOOP_HANDLER);
+        int portOk = ok.getPort();
         try {
             forbidden.start();
             ok.start();
@@ -220,11 +220,11 @@ public class QwpQueryClientWalkTrackerTest {
         // loop would continue to the second host, producing a
         // QwpRoleMismatchException or accepting the second host -- both
         // mask the credential failure (failover.md §6 AuthError).
-        int port401 = TestPorts.findUnusedPort();
-        int portOk = TestPorts.findUnusedPort();
-        TestWebSocketServer auth = new TestWebSocketServer(port401, NOOP_HANDLER);
+        TestWebSocketServer auth = new TestWebSocketServer(NOOP_HANDLER);
         auth.setRejectWithStatus(401, "Unauthorized");
-        TestWebSocketServer ok = new TestWebSocketServer(portOk, NOOP_HANDLER);
+        int port401 = auth.getPort();
+        TestWebSocketServer ok = new TestWebSocketServer(NOOP_HANDLER);
+        int portOk = ok.getPort();
         try {
             auth.start();
             ok.start();
@@ -266,13 +266,13 @@ public class QwpQueryClientWalkTrackerTest {
         // exercises the fall-through reset, not the role filter. The
         // SERVER_INFO-driven role filter (target=primary/replica) is
         // covered by a separate integration test in the parent QuestDB repo.
-        int portA = TestPorts.findUnusedPort();
-        int portB = TestPorts.findUnusedPort();
-        TestWebSocketServer a = new TestWebSocketServer(portA, NOOP_HANDLER);
+        TestWebSocketServer a = new TestWebSocketServer(NOOP_HANDLER);
         a.setRejectWithRole("REPLICA");
         a.setSendServerInfo(true);
-        TestWebSocketServer b = new TestWebSocketServer(portB, NOOP_HANDLER);
+        int portA = a.getPort();
+        TestWebSocketServer b = new TestWebSocketServer(NOOP_HANDLER);
         b.setRejectWithRole("REPLICA");
+        int portB = b.getPort();
         try {
             a.start();
             b.start();
@@ -305,12 +305,12 @@ public class QwpQueryClientWalkTrackerTest {
     public void testWalk_FirstReachablePrimaryWins() throws Exception {
         // First host is REPLICA-rejecting; second is a PRIMARY-advertising
         // server. WalkTracker must skip the first and bind to the second.
-        int portReplica = TestPorts.findUnusedPort();
-        int portPrimary = TestPorts.findUnusedPort();
-        TestWebSocketServer rep = new TestWebSocketServer(portReplica, NOOP_HANDLER);
+        TestWebSocketServer rep = new TestWebSocketServer(NOOP_HANDLER);
         rep.setRejectWithRole("REPLICA");
-        TestWebSocketServer prim = new TestWebSocketServer(portPrimary, NOOP_HANDLER, false, "PRIMARY");
+        int portReplica = rep.getPort();
+        TestWebSocketServer prim = new TestWebSocketServer(NOOP_HANDLER, false, "PRIMARY");
         prim.setSendServerInfo(true);
+        int portPrimary = prim.getPort();
         try {
             rep.start();
             prim.start();
@@ -337,10 +337,10 @@ public class QwpQueryClientWalkTrackerTest {
         // info is the decoded SERVER_INFO -- the branch that outlived the
         // v1-mismatch removal. A clean 101 ignores the upgrade-time role header,
         // so the rejection here is driven purely by the SERVER_INFO role.
-        int port = TestPorts.findUnusedPort();
-        TestWebSocketServer replica = new TestWebSocketServer(port, NOOP_HANDLER);
+        TestWebSocketServer replica = new TestWebSocketServer(NOOP_HANDLER);
         replica.setAdvertisedRole("REPLICA");
         replica.setSendServerInfo(true);
+        int port = replica.getPort();
         try {
             replica.start();
             Assert.assertTrue(replica.awaitStart(5, TimeUnit.SECONDS));
@@ -372,14 +372,14 @@ public class QwpQueryClientWalkTrackerTest {
         // REPLICA endpoint -- a SERVER_INFO role mismatch is a skip, not a
         // terminal failure -- and bind the PRIMARY one. Exercises the
         // walk-continues side of matchesTarget(info.getRole(), target).
-        int portReplica = TestPorts.findUnusedPort();
-        int portPrimary = TestPorts.findUnusedPort();
-        TestWebSocketServer replica = new TestWebSocketServer(portReplica, NOOP_HANDLER);
+        TestWebSocketServer replica = new TestWebSocketServer(NOOP_HANDLER);
         replica.setAdvertisedRole("REPLICA");
         replica.setSendServerInfo(true);
-        TestWebSocketServer primary = new TestWebSocketServer(portPrimary, NOOP_HANDLER);
+        int portReplica = replica.getPort();
+        TestWebSocketServer primary = new TestWebSocketServer(NOOP_HANDLER);
         primary.setAdvertisedRole("PRIMARY");
         primary.setSendServerInfo(true);
+        int portPrimary = primary.getPort();
         try {
             replica.start();
             primary.start();
@@ -408,12 +408,12 @@ public class QwpQueryClientWalkTrackerTest {
         // every connect, so a silent post-upgrade peer would otherwise stall the
         // client until the server-info timeout; bound it short here and verify
         // the walk falls through to a healthy node.
-        int portSilent = TestPorts.findUnusedPort();
-        int portOk = TestPorts.findUnusedPort();
-        TestWebSocketServer silent = new TestWebSocketServer(portSilent, NOOP_HANDLER);
+        TestWebSocketServer silent = new TestWebSocketServer(NOOP_HANDLER);
+        int portSilent = silent.getPort();
         // sendServerInfo left off: the 101 upgrade succeeds, then the node stays silent.
-        TestWebSocketServer ok = new TestWebSocketServer(portOk, NOOP_HANDLER);
+        TestWebSocketServer ok = new TestWebSocketServer(NOOP_HANDLER);
         ok.setSendServerInfo(true);
+        int portOk = ok.getPort();
         try {
             silent.start();
             ok.start();
@@ -438,9 +438,9 @@ public class QwpQueryClientWalkTrackerTest {
         // WalkTracker must classify the first as TransportError and bind
         // the second on the same walk (no fall-through reset needed yet).
         int portDead = TestPorts.findUnusedPort();
-        int portOk = TestPorts.findUnusedPort();
-        try (TestWebSocketServer ok = new TestWebSocketServer(portOk, NOOP_HANDLER)) {
+        try (TestWebSocketServer ok = new TestWebSocketServer(NOOP_HANDLER)) {
             ok.setSendServerInfo(true);
+            int portOk = ok.getPort();
             ok.start();
             Assert.assertTrue(ok.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/QwpWebSocketSenderTest.java
@@ -334,9 +334,9 @@ public class QwpWebSocketSenderTest {
     @Test
     public void testFlushAppendFailureDoesNotLeaveMicrobatchBufferInUse() throws Exception {
         assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, new TestWebSocketServer.WebSocketServerHandler() {
+            try (TestWebSocketServer server = new TestWebSocketServer(new TestWebSocketServer.WebSocketServerHandler() {
             })) {
+                int port = server.getPort();
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/ReconnectTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/ReconnectTest.java
@@ -67,9 +67,9 @@ public class ReconnectTest {
         // Without reconnect, the next batch's flush() would throw. With
         // reconnect, the I/O loop opens a fresh connection (same port,
         // same server) and the second batch goes through.
-        int port = TestPorts.findUnusedPort();
         DisconnectAfterFirstAckHandler handler = new DisconnectAfterFirstAckHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
@@ -101,14 +101,14 @@ public class ReconnectTest {
     }
 
     @Test
-    public void testReconnectGivesUpAfterCap() {
+    public void testReconnectGivesUpAfterCap() throws Exception {
         // Server is up at first (initial connect succeeds + ACKs batch 1),
         // then we tear it down — subsequent reconnect attempts get TCP
         // connection-refused and accumulate against the budget. With a
         // 500ms cap, the loop should give up well inside the test's 5s
         // poll window and the next user-thread flush() must throw.
-        int port = TestPorts.findUnusedPort();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, new AckHandler())) {
+        try (TestWebSocketServer server = new TestWebSocketServer(new AckHandler())) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
@@ -167,10 +167,10 @@ public class ReconnectTest {
         // a 401 happening on the very first reconnect, the cursor I/O
         // loop should surface the terminal error within hundreds of ms,
         // not after 10s.
-        int port = TestPorts.findUnusedPort();
         try (Auth401AfterFirstConnectionFixture fixture =
-                     new Auth401AfterFirstConnectionFixture(port)) {
+                     new Auth401AfterFirstConnectionFixture()) {
             fixture.start();
+            int port = fixture.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + ";reconnect_max_duration_millis=10000"
                     + ";close_flush_timeout_millis=0;";
@@ -220,9 +220,9 @@ public class ReconnectTest {
         // ackedFsn is still -1. On reconnect, the cursor must reposition at
         // FSN 0 and replay it — the new connection should observe the
         // *same* batch a second time before any new batch arrives.
-        int port = TestPorts.findUnusedPort();
         ReceiveThenDisconnectHandler handler = new ReceiveThenDisconnectHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
@@ -373,8 +373,16 @@ public class ReconnectTest {
         private volatile boolean running;
         private final java.util.List<Socket> openSockets = new java.util.concurrent.CopyOnWriteArrayList<>();
 
-        Auth401AfterFirstConnectionFixture(int port) throws IOException {
-            this.serverSocket = new ServerSocket(port);
+        Auth401AfterFirstConnectionFixture() throws IOException {
+            // Bind the listener up front on an OS-assigned loopback port and
+            // hold it for the fixture's lifetime; read it back via getPort().
+            // Owning the port from allocation to teardown avoids the bind race
+            // a pre-selected port would carry.
+            this.serverSocket = new ServerSocket(0, 50, java.net.InetAddress.getLoopbackAddress());
+        }
+
+        int getPort() {
+            return serverSocket.getLocalPort();
         }
 
         void start() {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/RecoveryReplayTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/RecoveryReplayTest.java
@@ -74,8 +74,8 @@ public class RecoveryReplayTest {
         // Phase 1: silent server, sender 1 writes enough to rotate at
         // least once, closes fast (no drain). Slot ends up with sealed +
         // active segments holding unacked data.
-        int port1 = TestPorts.findUnusedPort();
-        try (TestWebSocketServer silent = new TestWebSocketServer(port1, new SilentHandler())) {
+        try (TestWebSocketServer silent = new TestWebSocketServer(new SilentHandler())) {
+            int port1 = silent.getPort();
             silent.start();
             Assert.assertTrue(silent.awaitStart(5, TimeUnit.SECONDS));
 
@@ -111,9 +111,9 @@ public class RecoveryReplayTest {
         // sender 1 wrote (50 of them) reaches the new server. Without
         // the fix, the sender would only ship the active segment's data
         // (≪ 50) and orphan the sealed segments forever.
-        int port2 = TestPorts.findUnusedPort();
         AckHandler ack = new AckHandler();
-        try (TestWebSocketServer good = new TestWebSocketServer(port2, ack)) {
+        try (TestWebSocketServer good = new TestWebSocketServer(ack)) {
+            int port2 = good.getPort();
             good.start();
             Assert.assertTrue(good.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/SelfSufficientFramesTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/SelfSufficientFramesTest.java
@@ -62,9 +62,9 @@ public class SelfSufficientFramesTest {
         // batch 2 would emit deltaStart=1, deltaCount=1 — only the new
         // symbol. With self-sufficient frames, batch 2 must emit
         // deltaStart=0 covering BOTH symbols.
-        int port = TestPorts.findUnusedPort();
         CapturingHandler handler = new CapturingHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+            int port = server.getPort();
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/ServerErrorAckTerminalTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/ServerErrorAckTerminalTest.java
@@ -66,12 +66,12 @@ public class ServerErrorAckTerminalTest {
 
     @Test
     public void testServerErrorAckIsTerminalAndDoesNotBurnReconnectBudget() throws Exception {
-        int port = TestPorts.findUnusedPort();
         ErrorAckHandler handler = new ErrorAckHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             // Tight reconnect cadence so the pre-fix loop accumulates
             // attempts quickly inside our observation window.
             String cfg = "ws::addr=localhost:" + port
@@ -155,12 +155,12 @@ public class ServerErrorAckTerminalTest {
      */
     @Test
     public void testDropPolicyNackDoesNotHaltAndAdvancesAck() throws Exception {
-        int port = TestPorts.findUnusedPort();
         SchemaMismatchAckHandler handler = new SchemaMismatchAckHandler();
-        try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+        try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
             server.start();
             Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+            int port = server.getPort();
             String cfg = "ws::addr=localhost:" + port
                     + ";reconnect_max_duration_millis=10000"
                     + ";reconnect_initial_backoff_millis=10"

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/WriteFailoverTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/WriteFailoverTest.java
@@ -84,8 +84,8 @@ public class WriteFailoverTest {
             acceptor.start();
 
             AckHandler ack = new AckHandler();
-            goodPort = TestPorts.findUnusedPort();
-            try (TestWebSocketServer good = new TestWebSocketServer(goodPort, ack, false, "PRIMARY")) {
+            try (TestWebSocketServer good = new TestWebSocketServer(ack, false, "PRIMARY")) {
+                goodPort = good.getPort();
                 good.start();
                 Assert.assertTrue(good.awaitStart(5, TimeUnit.SECONDS));
 
@@ -117,12 +117,12 @@ public class WriteFailoverTest {
         // Two servers: server1 always rejects with 421 + REPLICA, server2
         // accepts with 101 + PRIMARY. The sender's connect path must walk
         // past server1 and land on server2 within the reconnect budget.
-        int port1 = TestPorts.findUnusedPort();
-        int port2 = TestPorts.findUnusedPort();
         AckHandler ack = new AckHandler();
-        TestWebSocketServer replica = new TestWebSocketServer(port1, ack);
+        TestWebSocketServer replica = new TestWebSocketServer(ack);
+        int port1 = replica.getPort();
         replica.setRejectWithRole("REPLICA");
-        TestWebSocketServer primary = new TestWebSocketServer(port2, ack, false, "PRIMARY");
+        TestWebSocketServer primary = new TestWebSocketServer(ack, false, "PRIMARY");
+        int port2 = primary.getPort();
         try {
             replica.start();
             primary.start();
@@ -152,12 +152,12 @@ public class WriteFailoverTest {
         // is promoted (clear the reject) and we verify the sender stays on
         // server2 — currentAddressIndex stickiness means we don't rotate
         // off a healthy primary just because another node became writable.
-        int port1 = TestPorts.findUnusedPort();
-        int port2 = TestPorts.findUnusedPort();
         AckHandler ack = new AckHandler();
-        TestWebSocketServer s1 = new TestWebSocketServer(port1, ack);
+        TestWebSocketServer s1 = new TestWebSocketServer(ack);
+        int port1 = s1.getPort();
         s1.setRejectWithRole("REPLICA");
-        TestWebSocketServer s2 = new TestWebSocketServer(port2, ack, false, "PRIMARY");
+        TestWebSocketServer s2 = new TestWebSocketServer(ack, false, "PRIMARY");
+        int port2 = s2.getPort();
         try {
             s1.start();
             s2.start();
@@ -194,11 +194,11 @@ public class WriteFailoverTest {
         // Off-mode walk that hits only replicas must surface
         // QwpRoleMismatchException — the walked address list resembles
         // a deployment mid-failover, distinguishable from "all hosts down".
-        int port1 = TestPorts.findUnusedPort();
-        int port2 = TestPorts.findUnusedPort();
-        TestWebSocketServer r1 = new TestWebSocketServer(port1, new AckHandler());
+        TestWebSocketServer r1 = new TestWebSocketServer(new AckHandler());
+        int port1 = r1.getPort();
         r1.setRejectWithRole("REPLICA");
-        TestWebSocketServer r2 = new TestWebSocketServer(port2, new AckHandler());
+        TestWebSocketServer r2 = new TestWebSocketServer(new AckHandler());
+        int port2 = r2.getPort();
         r2.setRejectWithRole("PRIMARY_CATCHUP");
         try {
             r1.start();
@@ -232,12 +232,12 @@ public class WriteFailoverTest {
         // with NO inter-host backoff; only after every host has been
         // tried does it fail terminally. Java's prior off-mode tried
         // hosts[0] alone.
-        int port1 = TestPorts.findUnusedPort();
-        int port2 = TestPorts.findUnusedPort();
         AckHandler ack = new AckHandler();
-        TestWebSocketServer replica = new TestWebSocketServer(port1, ack);
+        TestWebSocketServer replica = new TestWebSocketServer(ack);
+        int port1 = replica.getPort();
         replica.setRejectWithRole("REPLICA");
-        TestWebSocketServer primary = new TestWebSocketServer(port2, ack, false, "PRIMARY");
+        TestWebSocketServer primary = new TestWebSocketServer(ack, false, "PRIMARY");
+        int port2 = primary.getPort();
         try {
             replica.start();
             primary.start();
@@ -265,12 +265,12 @@ public class WriteFailoverTest {
         // QwpRoleMismatchException (not a generic LineSenderException) so
         // operators can distinguish "no primary elected yet" from
         // "everything is down".
-        int port1 = TestPorts.findUnusedPort();
-        int port2 = TestPorts.findUnusedPort();
         AckHandler ack = new AckHandler();
-        TestWebSocketServer r1 = new TestWebSocketServer(port1, ack);
+        TestWebSocketServer r1 = new TestWebSocketServer(ack);
+        int port1 = r1.getPort();
         r1.setRejectWithRole("REPLICA");
-        TestWebSocketServer r2 = new TestWebSocketServer(port2, ack);
+        TestWebSocketServer r2 = new TestWebSocketServer(ack);
+        int port2 = r2.getPort();
         r2.setRejectWithRole("PRIMARY_CATCHUP");
         try {
             r1.start();
@@ -311,9 +311,9 @@ public class WriteFailoverTest {
         // OSS / single-node deployments advertise STANDALONE. The client
         // must accept that handshake without rotation since standalone
         // nodes are writable.
-        int port = TestPorts.findUnusedPort();
         AckHandler ack = new AckHandler();
-        try (TestWebSocketServer standalone = new TestWebSocketServer(port, ack, false, "STANDALONE")) {
+        try (TestWebSocketServer standalone = new TestWebSocketServer(ack, false, "STANDALONE")) {
+            int port = standalone.getPort();
             standalone.start();
             Assert.assertTrue(standalone.awaitStart(5, TimeUnit.SECONDS));
 
@@ -335,8 +335,8 @@ public class WriteFailoverTest {
         // diagnostics. With a single-replica config the off-mode walk
         // wraps it in QwpRoleMismatchException; the WebSocketUpgradeException
         // sits on the cause chain via initCause().
-        int port = TestPorts.findUnusedPort();
-        TestWebSocketServer replica = new TestWebSocketServer(port, new AckHandler());
+        TestWebSocketServer replica = new TestWebSocketServer(new AckHandler());
+        int port = replica.getPort();
         try (replica) {
             replica.setRejectWithRole("REPLICA");
             replica.start();

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/BackgroundDrainerEndToEndTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/BackgroundDrainerEndToEndTest.java
@@ -73,9 +73,9 @@ public class BackgroundDrainerEndToEndTest {
     @Test
     public void testDrainerEmptiesOrphanSlotAgainstAckServer() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port1 = TestPorts.findUnusedPort();
             // Phase 1: ghost sender against silent server. 30 frames; close fast.
-            try (TestWebSocketServer silent = new TestWebSocketServer(port1, new SilentHandler())) {
+            try (TestWebSocketServer silent = new TestWebSocketServer(new SilentHandler())) {
+                int port1 = silent.getPort();
                 silent.start();
                 Assert.assertTrue(silent.awaitStart(5, TimeUnit.SECONDS));
 
@@ -95,9 +95,9 @@ public class BackgroundDrainerEndToEndTest {
                     1, OrphanScanner.scan(sfDir, "primary").size());
 
             // Phase 2: foreground sender against ack server, with drain_orphans=on.
-            int port2 = TestPorts.findUnusedPort();
             AckHandler ack = new AckHandler();
-            try (TestWebSocketServer good = new TestWebSocketServer(port2, ack)) {
+            try (TestWebSocketServer good = new TestWebSocketServer(ack)) {
+                int port2 = good.getPort();
                 good.start();
                 Assert.assertTrue(good.awaitStart(5, TimeUnit.SECONDS));
 
@@ -139,8 +139,8 @@ public class BackgroundDrainerEndToEndTest {
     public void testDrainerLeavesFailedSentinelOnTerminalError() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
             // Drainer can't connect → exhausts its budget → drops .failed.
-            int port1 = TestPorts.findUnusedPort();
-            try (TestWebSocketServer silent = new TestWebSocketServer(port1, new SilentHandler())) {
+            try (TestWebSocketServer silent = new TestWebSocketServer(new SilentHandler())) {
+                int port1 = silent.getPort();
                 silent.start();
                 Assert.assertTrue(silent.awaitStart(5, TimeUnit.SECONDS));
                 String cfg1 = "ws::addr=localhost:" + port1
@@ -158,10 +158,10 @@ public class BackgroundDrainerEndToEndTest {
             // drainer should give up and drop .failed.
             // The foreground sender does need to start successfully, so we
             // give it its own working server on a different port.
-            int port2 = TestPorts.findUnusedPort();
             int unreachablePort = TestPorts.findUnusedPort();
             AckHandler fgAck = new AckHandler();
-            try (TestWebSocketServer fgServer = new TestWebSocketServer(port2, fgAck)) {
+            try (TestWebSocketServer fgServer = new TestWebSocketServer(fgAck)) {
+                int port2 = fgServer.getPort();
                 fgServer.start();
                 Assert.assertTrue(fgServer.awaitStart(5, TimeUnit.SECONDS));
                 // Sender targets fgServer; drainer would inherit the same

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/DurableAckIntegrationTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/DurableAckIntegrationTest.java
@@ -52,8 +52,6 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class DurableAckIntegrationTest {
 
-    private static int nextPort = 19_500;
-
     private String sfDir;
 
     @Before
@@ -89,12 +87,12 @@ public class DurableAckIntegrationTest {
         // the connection succeeds against a server that does NOT echo the
         // durable-ack confirmation, because the client never asked for it.
         TestUtils.assertMemoryLeak(() -> {
-            int port = allocPort();
             DurableAckCapableHandler handler = new DurableAckCapableHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler, false)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler, false)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port + ";sf_dir=" + sfDir + ";request_durable_ack=off;";
                 try (Sender sender = Sender.fromConfig(config)) {
                     sender.table("trades").longColumn("v", 1L).atNow();
@@ -110,12 +108,12 @@ public class DurableAckIntegrationTest {
         // Opting in must throw at connect, not silently leave the SF store
         // to grow until disk fills.
         TestUtils.assertMemoryLeak(() -> {
-            int port = allocPort();
             DurableAckCapableHandler handler = new DurableAckCapableHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler, false)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler, false)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port + ";sf_dir=" + sfDir + ";request_durable_ack=on;";
                 try (Sender ignored = Sender.fromConfig(config)) {
                     Assert.fail("expected connect to fail with QwpDurableAckMismatchException");
@@ -135,12 +133,12 @@ public class DurableAckIntegrationTest {
         // drains. The pair "OK-but-no-durable" -> grow, "durable-ack" -> drain
         // is the central durable-mode contract.
         TestUtils.assertMemoryLeak(() -> {
-            int port = allocPort();
             DurableAckCapableHandler handler = new DurableAckCapableHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler, true)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler, true)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port + ";sf_dir=" + sfDir
                         + ";request_durable_ack=on;close_flush_timeout_millis=5000;";
                 try (Sender sender = Sender.fromConfig(config)) {
@@ -169,10 +167,6 @@ public class DurableAckIntegrationTest {
                 // never advances.
             }
         });
-    }
-
-    private static int allocPort() {
-        return nextPort++;
     }
 
     private static byte[] buildDurableAckFrame(long seqTxn) {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/OrphanScanIntegrationTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/OrphanScanIntegrationTest.java
@@ -28,7 +28,6 @@ import io.questdb.client.Sender;
 import io.questdb.client.cutlass.qwp.client.sf.cursor.OrphanScanner;
 import io.questdb.client.std.Files;
 import io.questdb.client.std.ObjList;
-import io.questdb.client.test.cutlass.qwp.client.TestPorts;
 import io.questdb.client.test.cutlass.qwp.websocket.TestWebSocketServer;
 import io.questdb.client.test.tools.TestUtils;
 import org.junit.After;
@@ -74,14 +73,14 @@ public class OrphanScanIntegrationTest {
             // unacked .sfa files when the sender shuts down. Then the same
             // slot should be reported as an orphan when a second sender opens
             // with sender_id=primary and drain_orphans=true.
-            int port = TestPorts.findUnusedPort();
 
             // Phase 1: ghost writes + closes; never acked.
-            try (TestWebSocketServer ghostServer = new TestWebSocketServer(port, new SilentHandler())) {
+            try (TestWebSocketServer ghostServer = new TestWebSocketServer(new SilentHandler())) {
                 ghostServer.start();
                 Assert.assertTrue(ghostServer.awaitStart(5, TimeUnit.SECONDS));
 
-                String ghostCfg = "ws::addr=localhost:" + port
+                int ghostPort = ghostServer.getPort();
+                String ghostCfg = "ws::addr=localhost:" + ghostPort
                         + ";sf_dir=" + sfDir + ";sender_id=ghost;close_flush_timeout_millis=0;";
                 try (Sender ghost = Sender.fromConfig(ghostCfg)) {
                     ghost.table("foo").longColumn("v", 7L).atNow();
@@ -101,11 +100,12 @@ public class OrphanScanIntegrationTest {
             // can't directly assert the log output in this test, but the
             // call must not throw, and the primary's own slot must NOT
             // appear in a fresh scan (sender_id-filtered).
-            try (TestWebSocketServer primaryServer = new TestWebSocketServer(port + 1000, new AckHandler())) {
+            try (TestWebSocketServer primaryServer = new TestWebSocketServer(new AckHandler())) {
                 primaryServer.start();
                 Assert.assertTrue(primaryServer.awaitStart(5, TimeUnit.SECONDS));
 
-                String primaryCfg = "ws::addr=localhost:" + (port + 1000)
+                int primaryPort = primaryServer.getPort();
+                String primaryCfg = "ws::addr=localhost:" + primaryPort
                         + ";sf_dir=" + sfDir
                         + ";sender_id=primary"
                         + ";drain_orphans=true;";

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/SfFromConfigTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/SfFromConfigTest.java
@@ -27,7 +27,6 @@ package io.questdb.client.test.cutlass.qwp.client.sf;
 import io.questdb.client.Sender;
 import io.questdb.client.cutlass.line.LineSenderException;
 import io.questdb.client.std.Files;
-import io.questdb.client.test.cutlass.qwp.client.TestPorts;
 import io.questdb.client.test.cutlass.qwp.websocket.TestWebSocketServer;
 import io.questdb.client.test.tools.TestUtils;
 import org.junit.After;
@@ -60,12 +59,12 @@ public class SfFromConfigTest {
     @Test
     public void testFromConfigEnablesSfAndOwnsLog() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port + ";sf_dir=" + sfDir + ";";
                 try (Sender sender = Sender.fromConfig(config)) {
                     sender.table("foo").longColumn("v", 42L).atNow();
@@ -95,12 +94,12 @@ public class SfFromConfigTest {
     @Test
     public void testSfMaxBytesParsing() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port
                         + ";sf_dir=" + sfDir + ";sf_max_bytes=131072;";
                 try (Sender sender = Sender.fromConfig(config)) {
@@ -123,12 +122,12 @@ public class SfFromConfigTest {
             // Absence of sf_dir is the only way to disable SF — no separate
             // off switch. Verify a basic SF-less sender still works end-to-end
             // and creates no directory.
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port + ";";
                 try (Sender sender = Sender.fromConfig(config)) {
                     sender.table("foo").longColumn("v", 1L).atNow();
@@ -148,12 +147,12 @@ public class SfFromConfigTest {
     @Test
     public void testSfMaxTotalBytesAcceptsLargeValue() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 // 4 GiB > Integer.MAX_VALUE; pre-fix this would throw "invalid sf_max_total_bytes".
                 String config = "ws::addr=localhost:" + port
                         + ";sf_dir=" + sfDir
@@ -225,12 +224,12 @@ public class SfFromConfigTest {
     @Test
     public void testSfMaxBytesAcceptsSizeSuffixes() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 // 64m / 4g should parse identically to their byte-count equivalents.
                 String config = "ws::addr=localhost:" + port
                         + ";sf_dir=" + sfDir
@@ -250,12 +249,12 @@ public class SfFromConfigTest {
         TestUtils.assertMemoryLeak(() -> {
             // sender_id="primary" => slot dir <sfDir>/primary; the engine writes
             // its segments and lock there, leaving sibling slot dirs untouched.
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port
                         + ";sf_dir=" + sfDir + ";sender_id=primary;";
                 try (Sender sender = Sender.fromConfig(config)) {
@@ -277,12 +276,12 @@ public class SfFromConfigTest {
             // share a group root. The second open with a colliding id must
             // refuse to start — silently allowing it would interleave FSN
             // sequences on disk and corrupt recovery.
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String config = "ws::addr=localhost:" + port
                         + ";sf_dir=" + sfDir + ";";
                 try (Sender first = Sender.fromConfig(config)) {
@@ -306,12 +305,12 @@ public class SfFromConfigTest {
         TestUtils.assertMemoryLeak(() -> {
             // Two senders against the same group root with distinct sender_id
             // values are independent slots — both must start cleanly.
-            int port = TestPorts.findUnusedPort();
             AckHandler handler = new AckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 
+                int port = server.getPort();
                 String cfgA = "ws::addr=localhost:" + port
                         + ";sf_dir=" + sfDir + ";sender_id=a;";
                 String cfgB = "ws::addr=localhost:" + port

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/CursorWebSocketSendLoopReconnectLeakTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/CursorWebSocketSendLoopReconnectLeakTest.java
@@ -28,7 +28,6 @@ import io.questdb.client.Sender;
 import io.questdb.client.cutlass.http.client.WebSocketClient;
 import io.questdb.client.cutlass.qwp.client.QwpWebSocketSender;
 import io.questdb.client.cutlass.qwp.client.sf.cursor.CursorWebSocketSendLoop;
-import io.questdb.client.test.cutlass.qwp.client.TestPorts;
 import io.questdb.client.test.cutlass.qwp.websocket.TestWebSocketServer;
 import io.questdb.client.test.tools.TestUtils;
 import org.junit.Assert;
@@ -61,9 +60,9 @@ public class CursorWebSocketSendLoopReconnectLeakTest {
     @Test
     public void testCloseClosesLivePostReconnectClient() throws Exception {
         TestUtils.assertMemoryLeak(() -> {
-            int port = TestPorts.findUnusedPort();
             DisconnectAfterFirstAckHandler handler = new DisconnectAfterFirstAckHandler();
-            try (TestWebSocketServer server = new TestWebSocketServer(port, handler)) {
+            try (TestWebSocketServer server = new TestWebSocketServer(handler)) {
+                int port = server.getPort();
                 server.start();
                 Assert.assertTrue(server.awaitStart(5, TimeUnit.SECONDS));
 

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/websocket/TestWebSocketServer.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/websocket/TestWebSocketServer.java
@@ -59,6 +59,7 @@ public class TestWebSocketServer implements Closeable {
     private final WebSocketServerHandler handler;
     private final int port;
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final ServerSocket serverSocket;
     private final CountDownLatch startLatch = new CountDownLatch(1);
     private Thread acceptThread;
     // X-QuestDB-Role value to emit on handshake responses. null = omit the
@@ -83,10 +84,9 @@ public class TestWebSocketServer implements Closeable {
     // 401, 403, 404, 426, 503, etc. that the failover loop should
     // classify per failover.md §6.
     private volatile String rejectingStatusReason;
-    private ServerSocket serverSocket;
 
-    public TestWebSocketServer(int port, WebSocketServerHandler handler) {
-        this(port, handler, false);
+    public TestWebSocketServer(WebSocketServerHandler handler) throws IOException {
+        this(handler, false);
     }
 
     /**
@@ -97,8 +97,8 @@ public class TestWebSocketServer implements Closeable {
      *                             that silently ignores the request and force
      *                             the client's early-fail check.
      */
-    public TestWebSocketServer(int port, WebSocketServerHandler handler, boolean emitDurableAckHeader) {
-        this(port, handler, emitDurableAckHeader, null);
+    public TestWebSocketServer(WebSocketServerHandler handler, boolean emitDurableAckHeader) throws IOException {
+        this(handler, emitDurableAckHeader, null);
     }
 
     /**
@@ -108,12 +108,20 @@ public class TestWebSocketServer implements Closeable {
      *                       handshakes. Pass {@code null} for legacy handshakes
      *                       without the header.
      */
-    public TestWebSocketServer(int port, WebSocketServerHandler handler,
-                               boolean emitDurableAckHeader, String advertisedRole) {
-        this.port = port;
+    public TestWebSocketServer(WebSocketServerHandler handler,
+                               boolean emitDurableAckHeader, String advertisedRole) throws IOException {
         this.handler = handler;
         this.emitDurableAckHeader = emitDurableAckHeader;
         this.advertisedRole = advertisedRole;
+        // Bind the listener up front and hold it open for the server's whole
+        // lifetime, then read the OS-assigned ephemeral port back via getPort().
+        // Owning the socket from allocation to teardown closes the window in
+        // which another process could grab a pre-selected port before start()
+        // binds it. Pinning to loopback keeps client "localhost" connections
+        // routed here rather than to a wildcard listener on the same port.
+        serverSocket = new ServerSocket(0, 50, java.net.InetAddress.getLoopbackAddress());
+        serverSocket.setSoTimeout(100);
+        this.port = serverSocket.getLocalPort();
     }
 
     public boolean awaitStart(long timeout, TimeUnit unit) throws InterruptedException {
@@ -148,6 +156,14 @@ public class TestWebSocketServer implements Closeable {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Returns the loopback port the listener is bound to. Stable for the
+     * server's whole lifetime; safe to read immediately after construction.
+     */
+    public int getPort() {
+        return port;
     }
 
     /**
@@ -232,15 +248,8 @@ public class TestWebSocketServer implements Closeable {
             return;
         }
 
-        // Bind explicitly to the loopback address. The wildcard 0.0.0.0
-        // default lets a leftover process holding 127.0.0.1:port coexist
-        // on the same port under BSD/macOS SO_REUSEADDR semantics, and
-        // client connections to "localhost" then route to the more-specific
-        // listener instead of this mock. Pinning to loopback forces the
-        // kernel to detect the conflict and pick a different ephemeral port.
-        serverSocket = new ServerSocket(port, 50, java.net.InetAddress.getLoopbackAddress());
-        serverSocket.setSoTimeout(100);
-
+        // The listener is already bound (see the constructor); just spin up the
+        // accept loop on it.
         acceptThread = new Thread(() -> {
             startLatch.countDown();
             while (running.get()) {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/websocket/TestWebSocketServer.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/websocket/TestWebSocketServer.java
@@ -136,12 +136,10 @@ public class TestWebSocketServer implements Closeable {
         // close their sockets below — if the listener is still up, those
         // reconnects succeed and the new connections are never tracked here,
         // leaving them alive past close().
-        if (serverSocket != null) {
-            try {
-                serverSocket.close();
-            } catch (IOException e) {
-                // ignore
-            }
+        try {
+            serverSocket.close();
+        } catch (IOException e) {
+            // ignore
         }
 
         for (ClientHandler client : clients) {


### PR DESCRIPTION
## Problem

The WebSocket client test suite intermittently failed with `java.net.BindException: Address already in use`, e.g.:

```
QwpQueryClientWalkTrackerTest.testWalk_426UpgradeRequiredIsTransportNotTerminal:114
  » Bind Address already in use   (at TestWebSocketServer.start)
```

The cause is a time-of-check-to-time-of-use port race. `TestPorts.findUnusedPort()` opened an ephemeral `ServerSocket`, read its port, then closed it — releasing the port. `TestWebSocketServer.start()` re-bound that port only later, so in the gap another process (or the very next `findUnusedPort()` call, since nothing held the port) could take it. The failure is timing- and load-dependent, so it shows up as a rare flake on busy CI runners rather than deterministically.

## Fix

`TestWebSocketServer` now binds its loopback listener eagerly in the constructor, holds it for the server's whole lifetime, and exposes the OS-assigned port via `getPort()`. `start()` just launches the accept loop on the already-bound socket. Owning the port from allocation to teardown closes the race window entirely.

Call sites no longer pre-allocate a port: each test reads `server.getPort()` after constructing the server. `findUnusedPort()` remains only where a test points a client at a deliberately-dead endpoint (no server bound). The two raw `ServerSocket` fixtures that carried the same race (`Always401Fixture`, `Auth401AfterFirstConnectionFixture`) adopt the same eager-bind pattern; the other raw fixtures already used it. The change also removes two latent same-class hazards the migration surfaced: the sequential fixed-port `allocPort()` in `DurableAckIntegrationTest` and the `port1 + 50` guess in `CleanShutdownNoReplayTest`.

## Tradeoffs

Eager binding means the listener is accept-able at the TCP level from construction rather than from `start()`. For "server arrives late" tests this changes the *cause* of a pre-`start()` connection failure (upgrade timeout instead of
connection-refused) but not the outcome: there is no accept loop until `start()`, so the client still fails and retries, and the assertions are about end state. Those tests pass unchanged. A minor side effect is some benign `Handshake failed` server logs when a stale pre-`start()` connection is drained after the accept loop starts.

The diff is broad (19 files) because the helper is widely used, but each call-site change is mechanical: drop the pre-allocated port argument, read `getPort()` instead.

## Test plan

- Ran the full `core` test suite after the `main` merge and compile fix (`ff631e4`): 2326 tests, 0 failures, 0 errors, 1 skipped
- Confirmed the originally-failing `QwpQueryClientWalkTrackerTest` passes
- Verified the timing-sensitive classes (`InitialConnectAsyncTest`, `InitialConnectRetryTest`, `CloseDrainTest`, `RecoveryReplayTest`, `ReconnectTest`) pass, including the "server arrives late" scenarios
- Grepped to confirm no remaining `new TestWebSocketServer(port, ...)` calls and no raw `ServerSocket` bound to a pre-selected port
