### PR TITLE
chore(qwp): quiet only test-only drainer setup-failure log noise

### DIFF
--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/sf/cursor/BackgroundDrainer.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/sf/cursor/BackgroundDrainer.java
@@ -313,7 +313,18 @@ public final class BackgroundDrainer implements Runnable {
             outcome = DrainOutcome.STOPPED;
         } catch (Throwable t) {
             String msg = t.getMessage();
-            LOG.error("drainer setup failed for slot {}: {}", slotPath, msg, t);
+            if (slotPath != null) {
+                // Real orphan slot: a setup failure means unacked data on disk
+                // could not be drained to the server -- a durability concern
+                // that stays at ERROR so operators see it.
+                LOG.error("drainer setup failed for slot {}: {}", slotPath, msg, t);
+            } else if (LOG.isDebugEnabled()) {
+                // Only @TestOnly drainers carry a null slot (zero segment size);
+                // they fast-fail by design and would otherwise flood CI logs.
+                // The isDebugEnabled() guard avoids the varargs array and the
+                // message formatting when DEBUG is off, so it makes no garbage.
+                LOG.debug("drainer setup failed for slot {}: {}", slotPath, msg, t);
+            }
             lastErrorMessage = msg;
             try {
                 OrphanScanner.markFailed(slotPath, "setup: " + msg);


### PR DESCRIPTION
## What

`BackgroundDrainer.run()` logged every setup failure at `ERROR` with a full
stack trace. The `@TestOnly` no-arg drainer constructs with a `null` slot and
zero segment size, so it fails fast by design as soon as it runs. Tests that
exercise the pool through that constructor — `BackgroundDrainerPoolListenerTest`
and `BackgroundDrainerPoolRaceTest` — each emit a burst of these stack traces
(`drainer setup failed for slot null: segmentSizeBytes too small: 0`), which
floods the test console with noise unrelated to any real problem.

## Change

Discriminate on the slot path in the catch-all:

- **Real orphan slot (`slotPath != null`)** keeps `ERROR`. In production a drainer
  always carries a non-null slot path from `OrphanScanner`, and a setup failure
  there means unacked data buffered on disk could not be drained to the server —
  a durability signal operators must see. This path is unchanged.
- **Synthetic test path (`slotPath == null`)** drops to `DEBUG`, guarded by
  `if (LOG.isDebugEnabled())` so SLF4J allocates no varargs array and formats no
  message when `DEBUG` is off.

An earlier revision of this PR demoted the whole catch-all to `DEBUG`. That was
wrong: it would have hidden genuine production drain failures, not just test
noise. This revision keeps the production signal intact and quiets only the
test-only path.

## Test plan

- `mvn -pl core compile` passes.
- `BackgroundDrainerPoolListenerTest` and `BackgroundDrainerPoolRaceTest` still
  pass; they assert on drainer/pool state, not on log output.
- Those tests no longer print the setup-failure stack-trace burst at default
  log level.
- Production behavior for real orphan slots is unchanged — failures still log at
  `ERROR`.