### PR TITLE
test(qwp): fix flaky cold-start timing in async close-drain test

### DIFF
--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/CloseDrainTest.java
@@ -358,14 +358,20 @@ public class CloseDrainTest {
                         + ";reconnect_initial_backoff_millis=20"
                         + ";reconnect_max_backoff_millis=100"
                         + ";close_flush_timeout_millis=3000;";
-                long t0 = System.nanoTime();
                 try (Sender sender = Sender.fromConfig(cfg)) {
                     sender.table("foo").longColumn("v", i).atNow();
                     sender.flush();
+                    // Time only close(): the 2500ms budget covers close()'s
+                    // drain latency. Building the first store-and-forward
+                    // sender carries a one-time cold-start cost (class
+                    // loading, JIT, sf buffer mmap) that belongs to
+                    // construction, not to close().
+                    long t0 = System.nanoTime();
+                    sender.close();
+                    long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+                    Assert.assertTrue("iteration " + i + " close() took " + elapsedMs + "ms",
+                            elapsedMs < 2500);
                 }
-                long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
-                Assert.assertTrue("iteration " + i + " close() took " + elapsedMs + "ms",
-                        elapsedMs < 2500);
             }
         }
     }


### PR DESCRIPTION
## Problem

`CloseDrainTest.testAsyncCloseDrainSucceedsWhenServerWasUpAllAlong` runs 20
iterations. Each iteration constructs a store-and-forward async `Sender`, writes
and flushes one row, then closes the sender and asserts that close completes
within a 2500ms budget. That budget targets the latency of `close()`'s drain,
but the test timed the whole `try (Sender sender = Sender.fromConfig(cfg)) {
...; flush(); }` block — construction *and* close — against it.

Iteration 0 builds the first store-and-forward async sender in the JVM, so
`fromConfig` pays a one-time cold-start cost: class loading, JIT warmup, and the
store-and-forward buffer mmap. On a loaded CI runner that cold start reached
~3.26s and tripped the 2500ms assertion, even though `close()` itself took
~12ms. The failure is load-dependent, so it surfaced as a rare flake on busy
runners rather than deterministically.

## Fix

Move the `t0 = System.nanoTime()` start inside the try block so the timed region
wraps only `sender.close()`. This matches the sibling test
`testAsyncCloseDrainSucceedsWhenServerStartsDuringDrain`, which already times
`close()` alone. The cold-start cost now sits outside the measured window, where
it belongs: the assertion was always about drain latency, not sender
construction.

`QwpWebSocketSender.close()` is idempotent — it guards on a `closed` flag and
returns immediately on the second call — so the try-with-resources auto-close at
the end of the block is a no-op.

## Tradeoffs

The test no longer bounds `fromConfig`/construction time at all. That was never
its intent — the 2500ms budget targets the close/drain path — and construction
runs in every other test in the suite, so this is not a coverage loss here. A
genuine construction-time regression would need a dedicated test rather than
being caught incidentally by this one.

## Test plan

- Ran `CloseDrainTest#testAsyncCloseDrainSucceedsWhenServerWasUpAllAlong` and
  `#testAsyncCloseDrainSucceedsWhenServerStartsDuringDrain` locally: 2 tests
  run, 0 failures, 0 errors
- Confirmed the 20-iteration `WasUpAllAlong` test passes with the close-only
  timer; every iteration's `close()` completed within the 2500ms budget
- Verified `QwpWebSocketSender.close()` guards on its `closed` flag, so the
  implicit try-with-resources close is a no-op
