### PR TITLE
fix(qwp): fix a memory-access fault and worker leak during shutdown

### DIFF
--- a/core/src/main/java/io/questdb/client/cutlass/qwp/client/sf/cursor/SegmentManager.java
+++ b/core/src/main/java/io/questdb/client/cutlass/qwp/client/sf/cursor/SegmentManager.java
@@ -67,6 +67,7 @@ public final class SegmentManager implements QuietCloseable {
     public static final long DISK_FULL_LOG_THROTTLE_NANOS = 30_000_000_000L; // 30 s
     public static final long UNLIMITED_TOTAL_BYTES = Long.MAX_VALUE;
     private static final Logger LOG = LoggerFactory.getLogger(SegmentManager.class);
+    private static final long WORKER_JOIN_TIMEOUT_MILLIS = 5_000L;
 
     private final AtomicLong fileGeneration = new AtomicLong();
     private final Object lock = new Object();
@@ -107,6 +108,7 @@ public final class SegmentManager implements QuietCloseable {
     // {@link #lock}; the lock covers both paths so the counter stays
     // consistent across registration boundaries.
     private long totalBytes;
+    private long workerJoinTimeoutMillis = WORKER_JOIN_TIMEOUT_MILLIS;
     // volatile because wakeWorker() reads workerThread without holding the
     // monitor; the synchronized start()/close() pair handles the
     // start-vs-close ordering.
@@ -168,10 +170,28 @@ public final class SegmentManager implements QuietCloseable {
         Thread t = workerThread;
         if (t != null) {
             LockSupport.unpark(t);
+            // A pending interrupt on the caller makes Thread.join() throw at
+            // once; clear it so the join actually reaps the worker (which
+            // still owns segment files), then restore it for the rest of the
+            // interrupted-teardown protocol.
+            boolean interrupted = Thread.interrupted();
+            long deadlineNanos = System.nanoTime() + workerJoinTimeoutMillis * 1_000_000L;
             try {
-                t.join(5_000);
-            } catch (InterruptedException ignored) {
-                Thread.currentThread().interrupt();
+                while (t.isAlive()) {
+                    long remainingMillis = (deadlineNanos - System.nanoTime()) / 1_000_000L;
+                    if (remainingMillis <= 0) {
+                        break;
+                    }
+                    try {
+                        t.join(remainingMillis);
+                    } catch (InterruptedException ignored) {
+                        interrupted = true;
+                    }
+                }
+            } finally {
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
             }
             if (t.isAlive()) {
                 LOG.warn("SegmentManager worker did not stop before close wait completed; "
@@ -285,6 +305,11 @@ public final class SegmentManager implements QuietCloseable {
     @TestOnly
     public void setBeforeTrimSyncHook(Runnable hook) {
         this.beforeTrimSyncHook = hook;
+    }
+
+    @TestOnly
+    public void setWorkerJoinTimeoutMillis(long millis) {
+        this.workerJoinTimeoutMillis = millis;
     }
 
     public synchronized void start() {

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SegmentManagerCloseRaceTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SegmentManagerCloseRaceTest.java
@@ -170,10 +170,7 @@ public class SegmentManagerCloseRaceTest {
                 Assert.assertTrue("precondition: path scratch should be allocated",
                         readPathScratchImpl(manager) != 0L);
 
-                // Exercise the same branch as a timed-out join without making
-                // the test sleep for 5 seconds: join() returns while the worker
-                // is still alive. close() must leave worker-owned native memory
-                // alone so the worker can resume safely.
+                manager.setWorkerJoinTimeoutMillis(50L);
                 Thread.currentThread().interrupt();
                 manager.close();
                 Assert.assertTrue("close should preserve interrupted status",
@@ -185,12 +182,92 @@ public class SegmentManagerCloseRaceTest {
                         readPathScratchImpl(manager) != 0L);
 
                 releaseWorker.countDown();
+                manager.setWorkerJoinTimeoutMillis(TimeUnit.SECONDS.toMillis(60));
                 manager.close();
                 managerClosed = true;
                 Assert.assertNull("successful close should clear workerThread",
                         readWorkerThread(manager));
                 Assert.assertEquals("successful close should free path scratch",
                         0L, readPathScratchImpl(manager));
+                if (hookErr.get() != null) {
+                    throw new AssertionError("install hook failed", hookErr.get());
+                }
+            } finally {
+                manager.setBeforeInstallSyncHook(null);
+                releaseWorker.countDown();
+                if (!managerClosed) {
+                    Thread.interrupted();
+                    manager.close();
+                }
+                ring.close();
+            }
+        });
+    }
+
+    @Test(timeout = 15_000L)
+    public void testInterruptedCallerDoesNotAbandonReapableWorker() throws Exception {
+        TestUtils.assertMemoryLeak(() -> {
+            long segSize = MmapSegment.HEADER_SIZE + (MmapSegment.FRAME_HEADER_SIZE + 32);
+            String slot = tmpDir + "/interrupt-slot";
+            Assert.assertEquals(0, Files.mkdir(slot, Files.DIR_MODE_DEFAULT));
+            MmapSegment initial = MmapSegment.create(slot + "/sf-initial.sfa", 0L, segSize);
+            SegmentRing ring = new SegmentRing(initial, segSize);
+            SegmentManager manager = new SegmentManager(segSize, TimeUnit.SECONDS.toNanos(60));
+            CountDownLatch workerBlocked = new CountDownLatch(1);
+            CountDownLatch releaseWorker = new CountDownLatch(1);
+            CountDownLatch closeReturned = new CountDownLatch(1);
+            AtomicBoolean fired = new AtomicBoolean();
+            AtomicBoolean interruptPreserved = new AtomicBoolean();
+            AtomicReference<Throwable> hookErr = new AtomicReference<>();
+            AtomicReference<Throwable> closeErr = new AtomicReference<>();
+            boolean managerClosed = false;
+            try {
+                manager.register(ring, slot);
+                manager.setBeforeInstallSyncHook(() -> {
+                    if (!fired.compareAndSet(false, true)) return;
+                    workerBlocked.countDown();
+                    try {
+                        if (!releaseWorker.await(10, TimeUnit.SECONDS)) {
+                            hookErr.compareAndSet(null,
+                                    new AssertionError("timed out waiting for test to release worker"));
+                        }
+                    } catch (Throwable t) {
+                        hookErr.compareAndSet(null, t);
+                    }
+                });
+                manager.start();
+                Assert.assertTrue("worker did not reach install hook",
+                        workerBlocked.await(5, TimeUnit.SECONDS));
+
+                Thread closer = new Thread(() -> {
+                    Thread.currentThread().interrupt();
+                    try {
+                        manager.close();
+                    } catch (Throwable t) {
+                        closeErr.compareAndSet(null, t);
+                    } finally {
+                        interruptPreserved.set(Thread.currentThread().isInterrupted());
+                        closeReturned.countDown();
+                    }
+                }, "interrupted-closer");
+                closer.start();
+
+                Assert.assertFalse("interrupted close() abandoned a live worker instead of waiting",
+                        closeReturned.await(300, TimeUnit.MILLISECONDS));
+
+                releaseWorker.countDown();
+                Assert.assertTrue("close() never returned after the worker was released",
+                        closeReturned.await(10, TimeUnit.SECONDS));
+                closer.join(TimeUnit.SECONDS.toMillis(5));
+                managerClosed = readWorkerThread(manager) == null;
+
+                if (closeErr.get() != null) {
+                    throw new AssertionError("close() threw", closeErr.get());
+                }
+                Assert.assertNull("close() must reap the worker despite the pending interrupt",
+                        readWorkerThread(manager));
+                Assert.assertTrue("close() must restore the caller's interrupt status",
+                        interruptPreserved.get());
                 if (hookErr.get() != null) {
                     throw new AssertionError("install hook failed", hookErr.get());
                 }


### PR DESCRIPTION
## Summary

When the QWP client shuts down while a background drainer is still delivering a slot's buffered data, the drainer thread is interrupted as part of teardown. `SegmentManager.close()` reaps its worker thread with a bounded `t.join(...)`, but a pending interrupt on the calling thread makes `join()` throw `InterruptedException` immediately. `close()` then returned without the worker having stopped, leaking a live worker thread together with its native buffers.

The leaked worker keeps creating hot spares and trimming/unlinking on-disk segment files. A later `CursorSendEngine` that memory-maps one of those files can race the concurrent truncation/unlink and take a SIGBUS, surfacing as:

```
java.lang.InternalError: a fault occurred in an unsafe memory access operation
```

The fault is intermittent -- it only triggers when the leaked worker happens to be mutating the exact file being mapped -- and showed up as a flaky failure in `BackgroundDrainerInterruptIsStopSignalTest`.

## Fix

`SegmentManager.close()` now saves and clears the caller's pending interrupt before joining the worker, waits the worker out to the same 5s deadline, then restores the interrupt so the rest of the interrupted-teardown protocol still observes it. The worker is a passive daemon that exits within microseconds of `running=false`, so in the common case `close()` still returns immediately; the deadline is only consumed when the worker is genuinely wedged -- the same bound the original code intended before the interrupt collapsed it to zero.

The change is deliberately narrow: only the worker join is hardened against a pending interrupt. The `loop.close()` latch await on the same teardown path stays interrupt-sensitive by design, since it must throw under a wedged I/O thread.

## Tradeoffs

- Under a pending caller interrupt, `close()` can now block up to the worker-join deadline (5s) where it previously returned at once. In practice the worker exits in microseconds; the wait only materializes when the worker is stuck, which is exactly the case where leaking it is unsafe.

## Tests

- Add `testInterruptedCallerDoesNotAbandonReapableWorker`, a deterministic regression: it wedges the worker, calls `close()` on an interrupted thread, and asserts `close()` waits for and reaps the worker. It fails against the pre-fix code and passes with the fix.
- Adjust `testCloseDoesNotFreePathScratchWhenWorkerStillAlive` to reach the join-timeout branch via a new `@TestOnly` worker-join-timeout seam instead of the interrupt shortcut the fix removes.
- Full `SegmentManager*` and `BackgroundDrainer*` suites pass, including `BackgroundDrainerInterruptedTeardownTest`, which pins the deliberately-preserved interrupt status.
