### PR TITLE
test(qwp): make error dispatcher overflow test deterministic

### DIFF
--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SenderConnectionDispatcherTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SenderConnectionDispatcherTest.java
@@ -100,10 +100,12 @@ public class SenderConnectionDispatcherTest {
         // entry and admit the new one. Later connection events carry the
         // freshest state, so dropping the head loses the least information.
         CountDownLatch unblock = new CountDownLatch(1);
+        CountDownLatch listenerEntered = new CountDownLatch(1);
         List<SenderConnectionEvent> received = new ArrayList<>();
         Object lock = new Object();
         CountDownLatch allDelivered = new CountDownLatch(5);
         try (SenderConnectionDispatcher d = new SenderConnectionDispatcher(ev -> {
+            listenerEntered.countDown();
             try {
                 unblock.await();
             } catch (InterruptedException ignored) {
@@ -114,11 +116,12 @@ public class SenderConnectionDispatcherTest {
             }
             allDelivered.countDown();
         }, /*capacity=*/ 4)) {
-            // First offer starts the dispatcher and lands in the listener
-            // immediately (and blocks there), freeing one slot. Now we can
-            // fill the bounded inbox to capacity (4), then overflow.
+            // First offer starts the dispatcher. Wait until it lands in the
+            // listener and blocks there before filling the bounded inbox and
+            // overflowing it.
             Assert.assertTrue(d.offer(buildEvent(0)));
-            TimeUnit.MILLISECONDS.sleep(50);
+            Assert.assertTrue("dispatcher should take the head into the listener within 5s",
+                    listenerEntered.await(5, TimeUnit.SECONDS));
             for (int i = 1; i <= 4; i++) {
                 Assert.assertTrue("inbox should accept offer " + i,
                         d.offer(buildEvent(i)));

--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SenderErrorDispatcherTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SenderErrorDispatcherTest.java
@@ -102,10 +102,12 @@ public class SenderErrorDispatcherTest {
         // and admit the new one. The latest entry is always the most
         // informative, so the FIFO head loses, not the new arrival.
         CountDownLatch unblock = new CountDownLatch(1);
+        CountDownLatch handlerEntered = new CountDownLatch(1);
         List<SenderError> received = new ArrayList<>();
         Object lock = new Object();
         CountDownLatch allDelivered = new CountDownLatch(5);
         try (SenderErrorDispatcher d = new SenderErrorDispatcher(err -> {
+            handlerEntered.countDown();
             try {
                 unblock.await();
             } catch (InterruptedException ignored) {
@@ -120,9 +122,11 @@ public class SenderErrorDispatcherTest {
             // immediately (and blocks there). Now we can fill the bounded
             // inbox to capacity, then overflow.
             Assert.assertTrue(d.offer(buildError(0)));
-            // Give the dispatcher a moment to take the head into the
-            // handler so subsequent offers don't get an extra slot.
-            TimeUnit.MILLISECONDS.sleep(50);
+            // The dispatcher polls the head off the inbox before invoking
+            // the handler, so once the handler is entered the head's slot
+            // is free and subsequent offers cannot get an extra slot.
+            Assert.assertTrue("dispatcher should take the head into the handler within 5s",
+                    handlerEntered.await(5, TimeUnit.SECONDS));
             for (int i = 1; i <= 4; i++) {
                 Assert.assertTrue("inbox should accept offer " + i,
                         d.offer(buildError(i)));


### PR DESCRIPTION
The QWP error dispatcher drops the oldest queued entry when its bounded inbox overflows. `testFullInboxDropsOldestAndCounts` fills the inbox to capacity and asserts that two offers beyond capacity produce exactly two drops.

The test slept 50ms after the first offer and assumed the dispatcher thread had already taken the head entry into the blocked handler, freeing an inbox slot. On a loaded Windows CI machine the thread start exceeded 50ms, so the inbox filled one offer early and the overflow path dropped three entries instead of two, failing the dropped-count assertion. Observed on a Windows CI run:

```
[ERROR] io.questdb.client.test.cutlass.qwp.client.sf.cursor.SenderErrorDispatcherTest.testFullInboxDropsOldestAndCounts -- Time elapsed: 0.291 s <<< FAILURE!
java.lang.AssertionError: expected:<2> but was:<3>
	at junit@4.13.2/org.junit.Assert.assertEquals(Assert.java:633)
	at io.questdb.test/io.questdb.client.test.cutlass.qwp.client.sf.cursor.SenderErrorDispatcherTest.testFullInboxDropsOldestAndCounts(SenderErrorDispatcherTest.java:136)

02:01:03.894 [main] WARN io.questdb.client.cutlass.qwp.client.sf.cursor.SenderErrorDispatcher -- error-dispatcher thread did not exit within drain deadline; abandoning 3 queued errors
```

The teardown warning corroborates the timeline: close() found the dispatcher blocked in the handler holding entry 3 with entries 4-6 still queued, so entries 0-2 were the dropped set -- the drop-oldest path itself behaved correctly.

The handler now counts down a `handlerEntered` latch on entry, and the test awaits it instead of sleeping. `dispatchLoop` polls the head off the inbox before invoking the handler, so the latch firing proves the slot is free and later offers cannot borrow it.
