### PR TITLE
test(qwp): fix flaky SenderErrorDispatcher overflow test

### DIFF
--- a/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SenderErrorDispatcherTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/qwp/client/sf/cursor/SenderErrorDispatcherTest.java
@@ -102,10 +102,12 @@ public class SenderErrorDispatcherTest {
         // and admit the new one. The latest entry is always the most
         // informative, so the FIFO head loses, not the new arrival.
         CountDownLatch unblock = new CountDownLatch(1);
+        CountDownLatch handlerEntered = new CountDownLatch(1);
         List<SenderError> received = new ArrayList<>();
         Object lock = new Object();
         CountDownLatch allDelivered = new CountDownLatch(5);
         try (SenderErrorDispatcher d = new SenderErrorDispatcher(err -> {
+            handlerEntered.countDown();
             try {
                 unblock.await();
             } catch (InterruptedException ignored) {
@@ -116,13 +118,15 @@ public class SenderErrorDispatcherTest {
             }
             allDelivered.countDown();
         }, /*capacity=*/ 4)) {
-            // First offer starts the dispatcher and lands in the handler
-            // immediately (and blocks there). Now we can fill the bounded
-            // inbox to capacity, then overflow.
+            // The first offer lazily starts the dispatcher thread, which
+            // takes the head into the handler and blocks there. Wait for
+            // that handoff: once the handler has entered, error 0 is out
+            // of the inbox, so the fill below starts from an empty queue.
+            // A fixed sleep here raced the lazy thread start on loaded CI
+            // agents and produced a third drop (expected 2, got 3).
             Assert.assertTrue(d.offer(buildError(0)));
-            // Give the dispatcher a moment to take the head into the
-            // handler so subsequent offers don't get an extra slot.
-            TimeUnit.MILLISECONDS.sleep(50);
+            Assert.assertTrue("handler should take the head within 5s",
+                    handlerEntered.await(5, TimeUnit.SECONDS));
             for (int i = 1; i <= 4; i++) {
                 Assert.assertTrue("inbox should accept offer " + i,
                         d.offer(buildError(i)));


### PR DESCRIPTION
### Problem

`SenderErrorDispatcherTest.testFullInboxDropsOldestAndCounts` fails intermittently on loaded CI agents:

```
java.lang.AssertionError: expected:<2> but was:<3>
    at SenderErrorDispatcherTest.testFullInboxDropsOldestAndCounts(SenderErrorDispatcherTest.java:136)
```

Observed in questdb/questdb `macwin` [build 260325](https://dev.azure.com/questdb/questdb/_build/results?buildId=260325) (`windows-other-2` job), which runs this suite against the client.

### Root cause

The test offers error 0 to a capacity-4 dispatcher whose handler blocks on a latch, then sleeps a fixed 50 ms and assumes the lazily-started dispatcher thread has taken error 0 out of the inbox by then. The drop count the test asserts is fully determined by consumer progress:

```
drops = offers - consumed_before_overflow - capacity
```

When the dispatcher thread wins the race, 7 - 1 - 4 = 2 drops. When thread start-up exceeds 50 ms, the inbox still holds error 0 during the fill, offers 4-6 each evict the head, and 7 - 0 - 4 = 3 drops fail the assertion. The failing run's close-time WARN ("abandoning 3 queued errors") matches the losing timeline exactly: the thread had taken one entry into the blocked handler, leaving three of the surviving four in the queue.

The production dispatcher behaves correctly in both timelines - it evicts the oldest entry and counts each eviction. Only the test's starting-state assumption races. The delivered-tail assertion (`{0, 3, 4, 5, 6}`) rests on the same assumption; the drop-count assertion just fires first.

### Fix

The handler counts down a `handlerEntered` latch on entry, and the test awaits that latch instead of sleeping. The dispatcher thread only invokes the handler after removing the head from the inbox, so once the latch releases, the fill provably starts from an empty queue and exactly two overflow drops follow on any scheduler.

The await bounds the wait at 5 s: if the dispatcher ever fails to start its thread or deliver the head, the test fails with an explicit "handler should take the head within 5s" message instead of a misleading drop-count mismatch. In the common case the latch releases well under the old 50 ms sleep, so the class runs a bit faster locally (~0.07 s vs ~0.34 s).

### Test plan

- `mvn -pl core -Dtest=SenderErrorDispatcherTest test` - 11/11 pass, three consecutive runs
- the fix removes the timing assumption by construction (the latch orders "head taken" before the fill) rather than enlarging the sleep, so repetition is corroboration, not the argument
