### PR TITLE
fix(build): stabilize the token-store rename retry test

### DIFF
--- a/core/src/main/java/io/questdb/client/cutlass/auth/FileTokenStore.java
+++ b/core/src/main/java/io/questdb/client/cutlass/auth/FileTokenStore.java
@@ -987,6 +987,10 @@ public final class FileTokenStore implements TokenStore {
 
 
     private static void replaceTarget(Path tmp, Path target) throws IOException {
+        replaceTarget(tmp, target, null);
+    }
+
+    private static void replaceTarget(Path tmp, Path target, Runnable beforeRetryForTesting) throws IOException {
         // atomically rename tmp over target. On Windows a concurrent reader in any process holding target open
         // can make the rename fail transiently with AccessDeniedException (a sharing violation); retry a few
         // times on a short backoff before giving up, so a routine read/write overlap does not needlessly degrade
@@ -1009,6 +1013,10 @@ public final class FileTokenStore implements TokenStore {
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                     break;
+                }
+                // Tests clear a real permission denial before the next move attempt.
+                if (beforeRetryForTesting != null) {
+                    beforeRetryForTesting.run();
                 }
             }
             try {

--- a/core/src/test/java/io/questdb/client/test/cutlass/auth/FileTokenStoreTest.java
+++ b/core/src/test/java/io/questdb/client/test/cutlass/auth/FileTokenStoreTest.java
@@ -73,8 +73,7 @@ import static io.questdb.client.test.tools.TestUtils.repeat;
 /**
  * Coverage for {@link FileTokenStore}.
  * <p>
- * PLATFORM SCOPE. CI runs Linux only, so the store's Windows-motivated arms are covered here to the extent a
- * POSIX host can reach them, and no further:
+ * PLATFORM SCOPE. POSIX hosts cover the store's Windows-motivated arms only to the extent described below:
  * <ul>
  *     <li>the {@code AccessDeniedException} retry in {@code replaceTarget} - the sharing violation a Windows
  *     reader holding the target open produces - IS exercised, by denying the rename with directory
@@ -765,47 +764,34 @@ public class FileTokenStoreTest {
         Assume.assumeFalse("a root process bypasses the directory permissions this denial relies on",
                 "root".equals(System.getProperty("user.name")));
         assertMemoryLeak(() -> {
-            // replaceTarget retries a denied rename because on WINDOWS a concurrent reader holding the target
-            // open makes the atomic replace fail transiently with AccessDeniedException. CI is Linux-only, so
-            // the denial is produced the one way a POSIX host can: rename(2) needs write permission on the
-            // containing directory, so taking it away denies the move exactly as the sharing violation does,
-            // and restoring it mid-retry stands in for the Windows reader closing its handle.
+            // A POSIX directory permission denial produces the same AccessDeniedException as a Windows
+            // sharing violation. Clear it on the calling thread after the first denied move.
             Path dir = storeDir();
             createStoreDir(dir);
             Path tmp = Files.write(dir.resolve("payload.tmp"), "NEW".getBytes(StandardCharsets.UTF_8));
             Path target = Files.write(dir.resolve("payload.json"), "OLD".getBytes(StandardCharsets.UTF_8));
 
-            Method replaceTarget = FileTokenStore.class.getDeclaredMethod("replaceTarget", Path.class, Path.class);
+            Method replaceTarget = FileTokenStore.class.getDeclaredMethod(
+                    "replaceTarget", Path.class, Path.class, Runnable.class);
             replaceTarget.setAccessible(true);
-            Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("r-x------"));
-            // Prove the denial is real on THIS host before the test rests on it. Without this the whole test
-            // passes vacuously wherever the mode bits do not bite - the first attempt inside replaceTarget
-            // simply succeeds and no retry is ever exercised.
-            try {
-                Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
-                Assert.fail("the rename must be denied while the store directory is not writable");
-            } catch (AccessDeniedException expected) {
-                // exactly what a Windows sharing violation produces, and what the retry loop is written for
-            }
-            Thread reopener = new Thread(() -> {
-                // after the first backoff (20ms) but well inside the 5-attempt budget
-                Os.sleep(30);
+            AtomicInteger retries = new AtomicInteger();
+            Runnable clearDenial = () -> {
+                retries.incrementAndGet();
                 try {
                     Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"));
                 } catch (IOException e) {
                     throw new AssertionError("could not restore the directory permissions", e);
                 }
-            }, "denial-clearer");
-            reopener.setDaemon(true);
-            reopener.start();
+            };
+            Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("r-x------"));
             try {
-                replaceTarget.invoke(null, tmp, target);
+                replaceTarget.invoke(null, tmp, target, clearDenial);
             } finally {
-                reopener.join(10_000);
-                // whatever happened above, leave the tree deletable
+                // Leave the tree deletable even if the move or the retry hook fails.
                 Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwx------"));
             }
 
+            Assert.assertEquals("the first move must be denied and the first retry must succeed", 1, retries.get());
             Assert.assertEquals("the retry must complete the replace once the denial clears",
                     "NEW", new String(Files.readAllBytes(target), StandardCharsets.UTF_8));
             Assert.assertFalse("an atomic move consumes the temp file", Files.exists(tmp));


### PR DESCRIPTION
## Summary

Fix a timing-sensitive token-store test that failed in the `mac-other` job in [QuestDB CI build 269255](https://dev.azure.com/questdb/questdb/_build/results?buildId=269255), reported in questdb/questdb#7263.

The test checks that replacing a file succeeds after a permission error. Previously, a background thread had about 80 ms to restore write permission. If that thread ran too late, the test failed even though the retry logic worked correctly.

The test now restores permission immediately after the first failed attempt, without a background thread. It checks that the operation retries exactly once, writes the expected contents, and leaves no temporary file. It also restores the original permissions even if the test fails.

Production behavior stays the same: retry limits, delays, and interrupt handling do not change. The implementation adds a private callback for the test and a null check on retries. The test still needs POSIX file permissions and skips execution as root. It does not test Windows file-sharing errors.

## Validation

- All 90 `FileTokenStoreTest` tests pass through Maven on macOS arm64 with Java 8 and Java 25.
- Applying the fix to current `main` adds no other Java changes. The only intervening commit changes the PR-title CI check.
- `git diff --check` passes.
